### PR TITLE
Reuse parser after free

### DIFF
--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -875,9 +875,9 @@ int codegen_write(const struct File* self, FILE* fp)
     put_parsing_table(parsing_table, cc, fp);
 
     // Dump the exported symbols
-    fprintf(fp, "void* %s_init()\n{\n"
-                "    static int inited = 0;\n"
-                "    if (inited)\n"
+    fprintf(fp, "static int parser_initialized = 0;\n"
+                "void* %s_init()\n{\n"
+                "    if (parser_initialized)\n"
                 "    {\n"
                 "        return &parser;\n"
                 "    }\n"
@@ -885,12 +885,17 @@ int codegen_write(const struct File* self, FILE* fp)
                 "    U32 error = parser_init(&parser);\n"
                 "    if (error)\n"
                 "        return NULL;\n\n"
-                "    inited = 1;\n"
+                "    parser_initialized = 1;\n"
                 "    return (void*)&parser;\n"
                 "}\n\n",
                 options.prefix);
-    fprintf(fp, "void %s_free(GrammarParser* self)\n{\n"
-                "    parser_free(self);"
+    fprintf(fp, "void %s_free(GrammarParser* self)\n"
+                "{\n"
+                "    if (parser_initialized)\n"
+                "    {\n"
+                "         parser_free(self);\n"
+                "         parser_initialized = 0;\n"
+                "    }\n"
                 "}\n\n",
                 options.prefix);
 

--- a/test/integration_test.c
+++ b/test/integration_test.c
@@ -14,6 +14,17 @@ void calc_free_buffers(void* self);
 void calc_free(void* self);
 double calc_parse(const void* self, const void* buffers, const char* input);
 
+CTEST(test_empty)
+{
+    void* parser = calc_init();
+    void* buffers = calc_allocate_buffers();
+
+    assert_double_equal(calc_parse(parser, buffers, "   "), 0, 0);
+
+    calc_free(parser);
+    calc_free_buffers(buffers);
+}
+
 CTEST(test_parser)
 {
     void* parser = calc_init();
@@ -27,6 +38,7 @@ CTEST(test_parser)
 }
 
 const static struct CMUnitTest left_scan_tests[] = {
+        cmocka_unit_test(test_empty),
         cmocka_unit_test(test_parser),
 };
 


### PR DESCRIPTION
Before this PR, a generated parser cannot be re-instantiated after being freed.