### PR TITLE
Reserve token ids for ascii value

### DIFF
--- a/include/neoast.h
+++ b/include/neoast.h
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <cre2.h>
 
+#define ASCII_MAX ('~' + 1)
+
 typedef uint8_t U8;
 typedef uint16_t U16;
 typedef uint32_t U32;
@@ -75,6 +77,7 @@ struct GrammarParser_prv
     U32 grammar_n;
     U32 lex_state_n;
     const U32* lex_n;
+    const U32* ascii_mappings;
     LexerRule* const* lexer_rules;
     const GrammarRule* grammar_rules;
     const char* const* token_names;

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -12,7 +12,9 @@ typedef enum
     KEY_VAL_HEADER, // Key not filled
     KEY_VAL_OPTION,
     KEY_VAL_TOKEN,
+    KEY_VAL_TOKEN_ASCII,
     KEY_VAL_TOKEN_TYPE,
+    KEY_VAL_TOKEN_TYPE_ASCII,
     KEY_VAL_TYPE,
     KEY_VAL_LEFT,
     KEY_VAL_RIGHT,
@@ -77,6 +79,7 @@ struct KeyVal
     key_val_t type;
     char* key;
     char* value;
+    uint64_t options;
     struct KeyVal* next;
 };
 

--- a/src/codegen/codegen_grammar.c
+++ b/src/codegen/codegen_grammar.c
@@ -8,14 +8,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <parsergen/canonical_collection.h>
-#include <util/util.h>
 
 #define WS_X "[\\s]+"
 #define WS_OPT "[\\s]*"
 #define ID_X "[A-z][A-z0-9]*"
 
 U32* GEN_parsing_table = NULL;
-const char* tok_names = "$ohud<xet|;{FKHlLGgTSMA";
 const char* tok_names_errors[] = {
         "eof",
         "option",
@@ -61,6 +59,7 @@ struct KeyVal* key_val_build(key_val_t type, char* key, char* value)
     self->type = type;
     self->key = key;
     self->value = value;
+    self->options = 0;
 
     return self;
 }
@@ -138,6 +137,17 @@ static I32 ll_token(const char* lex_text, CodegenUnion* lex_val)
                                      strdup(find_token_start), NULL);
     return TOK_OPTION;
 }
+static I32 ll_token_ascii(const char* lex_text, CodegenUnion* lex_val)
+{
+    const char* find_token_start = strchr(lex_text + 7, '\'');
+    char* key = NULL;
+    asprintf(&key, "ASCII_CHAR_0x%02X", find_token_start[1]);
+
+    lex_val->key_val = key_val_build(KEY_VAL_TOKEN_ASCII,
+                                     key, NULL);
+    lex_val->key_val->options = (U8)find_token_start[1];
+    return TOK_OPTION;
+}
 static I32 ll_start(const char* lex_text, CodegenUnion* lex_val)
 {
     const char* type_start = strchr(lex_text + 5, '<');
@@ -187,6 +197,20 @@ static I32 ll_token_with_type(const char* lex_text, CodegenUnion* lex_val)
                                      strndup(type_start + 1, type_end - type_start - 1));
     return TOK_OPTION;
 }
+static I32 ll_token_with_type_ascii(const char* lex_text, CodegenUnion* lex_val)
+{
+    const char* type_start = strchr(lex_text + 6, '<');
+    const char* type_end = strchr(type_start, '>');
+    const char* find_token_start = strchr(type_end + 1, '\'');
+    char* key = NULL;
+    asprintf(&key, "ASCII_CHAR_0x%02X", find_token_start[1]);
+
+    lex_val->key_val = key_val_build(KEY_VAL_TOKEN_TYPE_ASCII,
+                                     key,
+                                     strndup(type_start + 1, type_end - type_start - 1));
+    lex_val->key_val->options = (U8)find_token_start[1];
+    return TOK_OPTION;
+}
 static I32 ll_left(const char* lex_text, CodegenUnion* lex_val)
 {
     const char* find_token_start = lex_text + 6;
@@ -194,6 +218,16 @@ static I32 ll_left(const char* lex_text, CodegenUnion* lex_val)
         find_token_start++;
 
     lex_val->key_val = key_val_build(KEY_VAL_LEFT, strdup(find_token_start), NULL);
+    return TOK_OPTION;
+}
+static I32 ll_left_ascii(const char* lex_text, CodegenUnion* lex_val)
+{
+    const char* find_token_start = strchr(lex_text + 6, '\'');
+    char* key = NULL;
+    asprintf(&key, "ASCII_CHAR_0x%02X", find_token_start[1]);
+
+    lex_val->key_val = key_val_build(KEY_VAL_LEFT, key, NULL);
+    lex_val->key_val->options = (U8)find_token_start[1];
     return TOK_OPTION;
 }
 static I32 ll_right(const char* lex_text, CodegenUnion* lex_val)
@@ -205,6 +239,16 @@ static I32 ll_right(const char* lex_text, CodegenUnion* lex_val)
     lex_val->key_val = key_val_build(KEY_VAL_RIGHT, strdup(find_token_start), NULL);
     return TOK_OPTION;
 }
+static I32 ll_right_ascii(const char* lex_text, CodegenUnion* lex_val)
+{
+    const char* find_token_start = strchr(lex_text + 7, '\'');
+    char* key = NULL;
+    asprintf(&key, "ASCII_CHAR_0x%02X", find_token_start[1]);
+
+    lex_val->key_val = key_val_build(KEY_VAL_RIGHT, key, NULL);
+    lex_val->key_val->options = (U8)find_token_start[1];
+    return TOK_OPTION;
+}
 
 static I32 ll_g_rule(const char* lex_text, CodegenUnion* lex_val, U32 len)
 {
@@ -214,6 +258,13 @@ static I32 ll_g_rule(const char* lex_text, CodegenUnion* lex_val, U32 len)
 static I32 ll_g_tok (const char* lex_text, CodegenUnion* lex_val)
 {
     lex_val->token = token_build(strdup(lex_text));
+    return TOK_G_TOK;
+}
+static I32 ll_g_tok_ascii (const char* lex_text, CodegenUnion* lex_val)
+{
+    char* token = NULL;
+    asprintf(&token, "ASCII_CHAR_0x%02X", lex_text[1]);
+    lex_val->token = token_build(token);
     return TOK_G_TOK;
 }
 
@@ -360,12 +411,16 @@ static LexerRule ll_rules_s0[] = {
         {.regex_raw = "==", .expr = (lexer_expr) ll_enter_lex},
         {.regex_raw = "%option" WS_X ID_X"=\"[^\"]*\"", .expr = (lexer_expr) ll_option},
         {.regex_raw = "%token" WS_X ID_X, .expr = (lexer_expr) ll_token},
+        {.regex_raw = "%token" WS_X "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_token_ascii},
+        {.regex_raw = "%token" WS_OPT "<"ID_X">" WS_X ID_X, .expr = (lexer_expr) ll_token_with_type},
+        {.regex_raw = "%token" WS_OPT "<"ID_X">" WS_X "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_token_with_type_ascii},
         {.regex_raw = "%start" WS_OPT "<"ID_X">" WS_X ID_X, .expr = (lexer_expr) ll_start},
         {.regex_raw = "%state" WS_X ID_X, .expr = (lexer_expr) ll_state},
         {.regex_raw = "%type" WS_OPT "<"ID_X">" WS_X ID_X, .expr = (lexer_expr) ll_type},
-        {.regex_raw = "%token" WS_OPT "<"ID_X">" WS_X ID_X, .expr = (lexer_expr) ll_token_with_type},
         {.regex_raw = "%left" WS_X ID_X, .expr = (lexer_expr) ll_left},
+        {.regex_raw = "%left" WS_X "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_left_ascii},
         {.regex_raw = "%right" WS_X ID_X, .expr = (lexer_expr) ll_right},
+        {.regex_raw = "%right" WS_X "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_right_ascii},
         {.regex_raw = "%top", .tok = TOK_HEADER},
         {.regex_raw = "%union", .tok = TOK_UNION},
         {.regex_raw = "{", .expr = ll_match_brace},
@@ -388,6 +443,7 @@ static LexerRule ll_rules_grammar[] = {
         {.regex_raw = "[A-z_]+:", .expr = (lexer_expr) ll_g_rule},
         {.regex_raw = "{", .expr = (lexer_expr) ll_match_brace},
         {.regex_raw = "[A-z][A-z_0-9]*", .expr = (lexer_expr) ll_g_tok},
+        {.regex_raw = "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_g_tok_ascii},
         {.regex_raw = "\\|", .tok = TOK_G_OR},
         {.regex_raw = ";", .tok = TOK_G_TERM},
 };
@@ -587,6 +643,7 @@ int gen_parser_init(GrammarParser* self)
     self->action_token_n = TOK_GG_FILE;
     self->token_n = TOK_AUGMENT;
     self->token_names = tok_names_errors;
+    self->ascii_mappings = NULL;
 
     precedence_table[TOK_G_OR] = PRECEDENCE_LEFT;
 

--- a/src/codegen/codegen_grammar.c
+++ b/src/codegen/codegen_grammar.c
@@ -12,6 +12,7 @@
 #define WS_X "[\\s]+"
 #define WS_OPT "[\\s]*"
 #define ID_X "[A-z][A-z0-9]*"
+#define ASCII "'[\\x20-\\x7E]'"
 
 U32* GEN_parsing_table = NULL;
 const char* tok_names_errors[] = {
@@ -411,16 +412,16 @@ static LexerRule ll_rules_s0[] = {
         {.regex_raw = "==", .expr = (lexer_expr) ll_enter_lex},
         {.regex_raw = "%option" WS_X ID_X"=\"[^\"]*\"", .expr = (lexer_expr) ll_option},
         {.regex_raw = "%token" WS_X ID_X, .expr = (lexer_expr) ll_token},
-        {.regex_raw = "%token" WS_X "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_token_ascii},
+        {.regex_raw = "%token" WS_X ASCII, .expr = (lexer_expr) ll_token_ascii},
         {.regex_raw = "%token" WS_OPT "<"ID_X">" WS_X ID_X, .expr = (lexer_expr) ll_token_with_type},
-        {.regex_raw = "%token" WS_OPT "<"ID_X">" WS_X "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_token_with_type_ascii},
+        {.regex_raw = "%token" WS_OPT "<"ID_X">" WS_X ASCII, .expr = (lexer_expr) ll_token_with_type_ascii},
         {.regex_raw = "%start" WS_OPT "<"ID_X">" WS_X ID_X, .expr = (lexer_expr) ll_start},
         {.regex_raw = "%state" WS_X ID_X, .expr = (lexer_expr) ll_state},
         {.regex_raw = "%type" WS_OPT "<"ID_X">" WS_X ID_X, .expr = (lexer_expr) ll_type},
         {.regex_raw = "%left" WS_X ID_X, .expr = (lexer_expr) ll_left},
-        {.regex_raw = "%left" WS_X "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_left_ascii},
+        {.regex_raw = "%left" WS_X ASCII, .expr = (lexer_expr) ll_left_ascii},
         {.regex_raw = "%right" WS_X ID_X, .expr = (lexer_expr) ll_right},
-        {.regex_raw = "%right" WS_X "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_right_ascii},
+        {.regex_raw = "%right" WS_X ASCII, .expr = (lexer_expr) ll_right_ascii},
         {.regex_raw = "%top", .tok = TOK_HEADER},
         {.regex_raw = "%union", .tok = TOK_UNION},
         {.regex_raw = "{", .expr = ll_match_brace},
@@ -443,7 +444,7 @@ static LexerRule ll_rules_grammar[] = {
         {.regex_raw = "[A-z_]+:", .expr = (lexer_expr) ll_g_rule},
         {.regex_raw = "{", .expr = (lexer_expr) ll_match_brace},
         {.regex_raw = "[A-z][A-z_0-9]*", .expr = (lexer_expr) ll_g_tok},
-        {.regex_raw = "'[\\x20-\\x7E]'", .expr = (lexer_expr) ll_g_tok_ascii},
+        {.regex_raw = ASCII, .expr = (lexer_expr) ll_g_tok_ascii},
         {.regex_raw = "\\|", .tok = TOK_G_OR},
         {.regex_raw = ";", .tok = TOK_G_TERM},
 };

--- a/src/common.h
+++ b/src/common.h
@@ -8,7 +8,7 @@
 #include <neoast.h>
 #include <stdint.h>
 
-#define ARR_LEN(arr) (sizeof(arr)) / sizeof((arr[0]))
+#define ARR_LEN(arr) ((sizeof(arr)) / sizeof(((arr)[0])))
 #define STACK_PUSH(stack, i) (stack)->data[((stack)->pos)++] = (i)
 #define STACK_POP(stack) (stack)->data[--((stack)->pos)]
 #define STACK_PEEK(stack) (stack)->data[(stack)->pos - 1]

--- a/src/lr.c
+++ b/src/lr.c
@@ -5,6 +5,7 @@
 #include <parser.h>
 #include <alloca.h>
 #include <string.h>
+#include <assert.h>
 
 static inline
 void* g_table_from_matrix(void* table,
@@ -46,7 +47,12 @@ U32 g_lr_reduce(
                val_s);
     }
 
-    int result_token = parser->grammar_rules[reduce_rule].token;
+    int result_token = (int)parser->grammar_rules[reduce_rule].token;
+    if (parser->ascii_mappings)
+    {
+        result_token -= ASCII_MAX;
+        assert(result_token > 0);
+    }
     if (parser->grammar_rules[reduce_rule].expr)
     {
         parser->grammar_rules[reduce_rule].expr(

--- a/src/util/table_dump.c
+++ b/src/util/table_dump.c
@@ -13,7 +13,7 @@ void dump_item(const LR_1* lr1, U32 tok_n, const char* tok_names, FILE* fp)
             fprintf(fp, "•");
         }
 
-        fprintf(fp, "%c", tok_names[lr1->grammar->grammar[i]]);
+        fprintf(fp, "%c", tok_names[lr1->grammar->grammar[i] < ASCII_MAX ? lr1->grammar->grammar[i] : lr1->grammar->grammar[i] - ASCII_MAX]);
     }
 
     if (lr1->final_item)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,10 +19,14 @@ add_mocked_test(tablegen_C
         )
 
 BuildParser(calculator_parser ${CMAKE_CURRENT_SOURCE_DIR}/input/calculator.y)
+BuildParser(calculator_ascii_parser ${CMAKE_CURRENT_SOURCE_DIR}/input/calculator_ascii.y)
 add_mocked_test(integration_C
         SOURCES
         input/calculator.y
-        integration_test.c ${calculator_parser_OUTPUT}
+        input/calculator_ascii.y
+        integration_test.c
+        ${calculator_parser_OUTPUT}
+        ${calculator_ascii_parser_OUTPUT}
         LINK_LIBRARIES neoast m
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         ENVIRONMENT ${EXEC_ENV}

--- a/test/input/calculator_ascii.y
+++ b/test/input/calculator_ascii.y
@@ -1,0 +1,69 @@
+%top {
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+// This is a calculator test program
+}
+
+// This is default, just want to test the parser
+%option parser_type="LALR(1)"
+//%option disable_locks="TRUE"
+%option debug_table="TRUE"
+%option debug_ids="$d+-/*^()ES"
+%option prefix="calc_ascii"
+
+%token<number> TOK_N
+%token '+'
+%token '-'
+%token '/'
+%token '*'
+%token '^'
+%token '('
+%token ')'
+
+%type <number> expr
+%type <number> program
+%start <number> program
+
+// Test global comment
+
+%left '+'
+%left '-'
+%left '*'
+%left '/'
+%right '^'
+
+%union {
+    double number;
+}
+
+==
+// Test lex rule comment
+"[ ]+"         {return -1;}
+"[0-9]+"       {yyval->number = strtod(yytext, NULL); return TOK_N;}
+"\\+"          {return '+';}
+"\\-"          {return '-';}
+"\\/"          {return '/';}
+"\\*"          {return '*';}
+"\\^"          {return '^';}
+"\\("          {return '(';}
+"\\)"          {return ')';}
+
+==
+
+%%
+// Test grammar rule comment
+program: expr     {$$ = $1;}
+     |            {$$ = 0;}
+     ;
+
+expr: TOK_N                {$$ = $1;}
+    | expr '+' expr        {$$ = $1 + $3;}
+    | expr '-' expr        {$$ = $1 - $3;}
+    | expr '/' expr        {$$ = $1 / $3;}
+    | expr '*' expr        {$$ = $1 * $3;}
+    | expr '^' expr        {$$ = pow($1, $3);}
+    | '(' expr ')'         {$$ = $2;}
+    ;
+%%

--- a/test/integration_test.c
+++ b/test/integration_test.c
@@ -14,6 +14,12 @@ void calc_free_buffers(void* self);
 void calc_free(void* self);
 double calc_parse(const void* self, const void* buffers, const char* input);
 
+void* calc_ascii_init();
+void* calc_ascii_allocate_buffers();
+void calc_ascii_free_buffers(void* self);
+void calc_ascii_free(void* self);
+double calc_ascii_parse(const void* self, const void* buffers, const char* input);
+
 CTEST(test_empty)
 {
     void* parser = calc_init();
@@ -37,9 +43,34 @@ CTEST(test_parser)
     calc_free(parser);
 }
 
+CTEST(test_empty_ascii)
+{
+    void* parser = calc_ascii_init();
+    void* buffers = calc_ascii_allocate_buffers();
+
+    assert_double_equal(calc_ascii_parse(parser, buffers, "   "), 0, 0);
+
+    calc_ascii_free(parser);
+    calc_ascii_free_buffers(buffers);
+}
+
+CTEST(test_parser_ascii)
+{
+    void* parser = calc_ascii_init();
+    void* buffers = calc_ascii_allocate_buffers();
+
+    const char* input = "3 + 5 + (4 * 2 + (5 / 2))";
+    double result = calc_ascii_parse(parser, buffers, input);
+    assert_double_equal(result, 3 + 5 + (4 * 2 + (5.0 / 2)), 0.001);
+    calc_ascii_free_buffers(buffers);
+    calc_ascii_free(parser);
+}
+
 const static struct CMUnitTest left_scan_tests[] = {
         cmocka_unit_test(test_empty),
         cmocka_unit_test(test_parser),
+        cmocka_unit_test(test_empty_ascii),
+        cmocka_unit_test(test_parser_ascii),
 };
 
 int main()


### PR DESCRIPTION
Token ids up to `127` are reserved for ASCII characters. Defined tokens are placed into `ascii_mappings` (`static const U32[]`).

The calculator test was rewritten to show this use case.

Closes #18

> Note: Only ASCII characters between `0x20` (`' '`) and `0x7E` (`'~'`) can be used in this way. If you want to define `token '\n'`, you need to assign a name like `token LF` instead.