### PR TITLE
Don't clone+build cmocka if no tests

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -33,7 +33,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DENABLE_NEOAST_TESTS=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -45,7 +45,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
 
-      run: cmake $GITHUB_WORKSPACE -DSANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DENABLE_NEOAST_TESTS=ON -DSANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(neoast VERSION "1.0")
 
 option(SANITIZER_BUILD "Build with AddressSanitizer" OFF)
 set(SANITIZER "" CACHE STRING "Compile with -fsanitize=...")
+option(ENABLE_NEOAST_TESTS "Build+execute neoast's tests" OFF)
 set(ASAN_LIB "libasan.so" CACHE STRING "Path to address sanitizer library")
 set(RE2_BUILD_TESTING CACHE STRING OFF)
 
@@ -28,4 +29,7 @@ add_subdirectory(src)
 add_subdirectory(third_party)
 
 include(cmake/neoast.cmake)
-add_subdirectory(test)
+
+if (ENABLE_NEOAST_TESTS)
+    add_subdirectory(test)
+endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(cmocka EXCLUDE_FROM_ALL)
+if (ENABLE_NEOAST_TESTS)
+    add_subdirectory(cmocka EXCLUDE_FROM_ALL)
+endif()
 
 set(RE2_BUILD_TESTING OFF)
 


### PR DESCRIPTION
Adds CMake option `ENABLE_NEOAST_TESTS` which defaults to `OFF`

Related to #10