### PR TITLE
Support regex macro expansion

### DIFF
--- a/include/neoast.h
+++ b/include/neoast.h
@@ -1,5 +1,6 @@
 #ifndef NEOAST_H
 #define NEOAST_H
+#define _GNU_SOURCE
 
 #include <stdint.h>
 #include <stdio.h>

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(
         neoast-exec
         main.c
-        codegen_grammar.c codegen.h codegen.c)
+        codegen_grammar.c codegen.h codegen.c regex.c regex.h)
 
 include_directories(neoast-codegen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../)
 

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -1029,6 +1029,7 @@ int codegen_write(const struct File* self, FILE* fp)
     }
     free(ll_rules);
     free(ll_rule_count);
+    macro_engine_free(m_engine);
 
     return 0;
 }

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -1024,7 +1024,10 @@ int codegen_write(const struct File* self, FILE* fp)
 
     for (int i = 0; i < lex_state_n; i++)
     {
-        free((char*)ll_rules[i]->regex_raw);
+        for (int j = 0; j < ll_rule_count[i]; j++)
+        {
+            free((char*)ll_rules[i][j].regex_raw);
+        }
         free(ll_rules[i]);
     }
     free(ll_rules);

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -8,6 +8,7 @@
 #include <lexer.h>
 #include "stdio.h"
 #include "codegen.h"
+#include "regex.h"
 #include <parsergen/canonical_collection.h>
 #include <util/util.h>
 #include <stddef.h>
@@ -252,26 +253,49 @@ void put_grammar_rule_action(
 }
 
 static inline
-void put_lexer_rule(LexerRule* self, FILE* fp)
+void put_lexer_rule_regex(LexerRule* self, FILE* fp)
+{
+    fputs("        ", fp);
+    for (const char* iter = self->regex_raw; *iter; iter++)
+    {
+        fprintf(fp, "0x%02x, ", *iter);
+    }
+
+    // Null terminator
+    fprintf(fp, "0x%02x,\n", 0);
+}
+
+static inline
+uint32_t put_lexer_rule(LexerRule* self, const char* state_name, uint32_t offset, FILE* fp)
 {
     if (self->expr)
     {
-        fprintf(fp, "        {.regex_raw = \"%s\", .expr = (lexer_expr) ll_rule_%p},\n",
-                self->regex_raw, self->expr);
+        fprintf(fp, "        {.regex_raw = &ll_rules_state_%s_regex_table[%d], .expr = (lexer_expr) ll_rule_%p}, // %s\n",
+                state_name, offset, self->expr, self->regex_raw);
     } else
     {
-
         // TODO Add support for quick token optimization in code gen
     }
+
+    return strlen(self->regex_raw) + 1;
 }
 
 static inline
 void put_lexer_state_rules(LexerRule* rules, int rules_n, const char* state_name, FILE* fp)
 {
-    fprintf(fp, "static LexerRule ll_rules_state_%s[] = {\n", state_name);
+    // First we need to build the regex table
+    fprintf(fp, "static const char ll_rules_state_%s_regex_table[] = {\n", state_name);
     for (int i = 0; i < rules_n; i++)
     {
-        put_lexer_rule(&rules[i], fp);
+        put_lexer_rule_regex(&rules[i], fp);
+    }
+    fputs("};\n\n", fp);
+
+    fprintf(fp, "static LexerRule ll_rules_state_%s[] = {\n", state_name);
+    uint32_t offset = 0;
+    for (int i = 0; i < rules_n; i++)
+    {
+        offset += put_lexer_rule(&rules[i], state_name, offset, fp);
     }
 
     fputs("};\n\n", fp);
@@ -512,8 +536,8 @@ int codegen_write(const struct File* self, FILE* fp)
     struct KeyVal* _start = NULL;
 
     int action_n = 1, token_n = 1, // reserved eof
-    typed_token_n = 0, precedence_n = 0,
-            macro_n = 0, lex_state_n = 1;
+        typed_token_n = 0, precedence_n = 0,
+        lex_state_n = 1;
 
     struct Options options = {
             .debug_table = 0,
@@ -525,6 +549,8 @@ int codegen_write(const struct File* self, FILE* fp)
             .max_lex_tokens = 1024,
             .max_lex_state_depth = 16
     };
+
+    MacroEngine* m_engine = macro_engine_init();
 
     // Iterate a single time though the header data
     // Count all of the different header option types
@@ -587,7 +613,7 @@ int codegen_write(const struct File* self, FILE* fp)
                 precedence_n++;
                 break;
             case KEY_VAL_MACRO:
-                macro_n++;
+                macro_engine_register(m_engine, iter->key, iter->value);
                 break;
             case KEY_VAL_STATE:
                 lex_state_n++;
@@ -615,7 +641,6 @@ int codegen_write(const struct File* self, FILE* fp)
     const struct KeyVal** typed_tokens = calloc(token_n, sizeof(struct KeyVal*));
 
     const char** lexer_states = malloc(sizeof(char*) * (lex_state_n));
-    const struct KeyVal** macros = malloc(sizeof(struct KeyVal*) * macro_n);
     uint8_t* precedence_table = calloc(token_n, sizeof(uint8_t));
 
     uint32_t ascii_mappings[ASCII_MAX] = {0};
@@ -651,8 +676,6 @@ int codegen_write(const struct File* self, FILE* fp)
             case KEY_VAL_STATE:
                 lexer_states[lex_state_i++] = iter->key;
                 break;
-            case KEY_VAL_MACRO:
-                macros[macro_i++] = iter;
             default:
                 break;
         }
@@ -673,11 +696,6 @@ int codegen_write(const struct File* self, FILE* fp)
                 precedence_table[token_id] = iter->type == KEY_VAL_LEFT ? PRECEDENCE_LEFT : PRECEDENCE_RIGHT;
 
                 break;
-            case KEY_VAL_TOKEN:
-            case KEY_VAL_TOKEN_TYPE:
-            case KEY_VAL_TYPE:
-            case KEY_VAL_STATE:
-            case KEY_VAL_MACRO:
             default:
                 break;
         }
@@ -689,7 +707,6 @@ int codegen_write(const struct File* self, FILE* fp)
     assert(action_i == action_n);
     assert(grammar_i == token_n);
     assert(lex_state_i == lex_state_n);
-    assert(macro_i == macro_n);
 
     // Write the header information
     fputs("#define NEOAST_PARSER_CODEGEN___C\n"
@@ -750,6 +767,8 @@ int codegen_write(const struct File* self, FILE* fp)
         ll_rules[i] = current;
         int iterator = 0;
 
+        // We're going to build a large array with every string embedded
+        uint32_t regex_length = 0;
         for (struct LexerRuleProto* iter = self->lexer_rules; iter; iter = iter->next)
         {
             if (iter->lexer_state && i != 0)
@@ -759,7 +778,13 @@ int codegen_write(const struct File* self, FILE* fp)
 
             LexerRule* ll_rule = &current[iterator++];
             ll_rule->expr = (lexer_expr) iter;
-            ll_rule->regex_raw = iter->regex;
+            ll_rule->regex_raw = regex_expand(m_engine, iter->regex);
+            regex_length += strlen(ll_rule->regex_raw) + 1; // We need to null terminator
+            if (!regex_verify(m_engine, ll_rule->regex_raw))
+            {
+                CODEGEN_ERROR("Failed to compile regular expression '%s'\n", ll_rule->regex_raw);
+            }
+
             ll_rule->tok = 0;
         }
 
@@ -994,12 +1019,12 @@ int codegen_write(const struct File* self, FILE* fp)
     free(grammar_table);
     free(typed_tokens);
     free(lexer_states);
-    free(macros);
     free(precedence_table);
     free(tokens);
 
     for (int i = 0; i < lex_state_n; i++)
     {
+        free((char*)ll_rules[i]->regex_raw);
         free(ll_rules[i]);
     }
     free(ll_rules);

--- a/src/codegen/codegen_grammar.c
+++ b/src/codegen/codegen_grammar.c
@@ -115,8 +115,8 @@ static int32_t ll_option(const char* lex_text, CodegenUnion* lex_val)
 static int32_t ll_macro(const char* lex_text, CodegenUnion* lex_val)
 {
     // Find the white space delimiter
-    char* split = strchr(lex_text, ' ');
-    char* key = strndup(lex_text, split - lex_text);
+    char* split = strchr(lex_text + 1, ' ');
+    char* key = strndup(lex_text + 1, split - lex_text - 1);
 
     // Find the start of the regex rule
     while (*split == ' ')

--- a/src/codegen/regex.c
+++ b/src/codegen/regex.c
@@ -1,0 +1,150 @@
+//
+// Created by tumbar on 1/16/21.
+//
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+#include "regex.h"
+
+MacroEngine* macro_engine_init()
+{
+    MacroEngine* self = malloc(sizeof(MacroEngine));
+    self->head = NULL;
+    self->opts = cre2_opt_new();
+    cre2_opt_set_one_line(self->opts, 1);
+    assert(self->opts && "re2 failed to allocate memory for options");
+
+    const char* pattern = "\\{[A-z][A-z0-9_]*\\}";
+
+    self->macro_pattern = cre2_new(pattern, strlen(pattern), self->opts);
+    assert(self->macro_pattern && "re2 failed to allocate memory for regex pattern");
+    assert(!cre2_error_code(self->macro_pattern) && "Failed to build macro");
+
+    return self;
+}
+
+static void macro_free_prv(Macro* self)
+{
+    Macro* next;
+    while (self)
+    {
+        next = self->next;
+        free(self->name);
+        free(self->expanded_regex);
+        free(self);
+        self = next;
+    }
+}
+
+void macro_engine_free(MacroEngine* self)
+{
+    macro_free_prv(self->head);
+    cre2_opt_delete(self->opts);
+    cre2_delete(self->macro_pattern);
+    free(self);
+}
+
+const char* macro_engine_get_macro(MacroEngine* self, const char* name, int name_length)
+{
+    for (Macro* iter = self->head; iter; iter = iter->next)
+    {
+        if (strncmp(iter->name, name, name_length) == 0)
+        {
+            return iter->expanded_regex;
+        }
+    }
+
+    return NULL;
+}
+
+char* regex_expand(MacroEngine* self, const char* regex)
+{
+    int length = (int)strlen(regex);
+    cre2_string_t input_str = {
+            .data = regex,
+            .length = length
+    };
+
+    cre2_string_t match_str;
+    char* expanded_pattern = NULL;
+
+    uint32_t offset = 0;
+
+    while (cre2_match(self->macro_pattern, regex, length, offset,
+                      length, CRE2_UNANCHORED, &match_str, 1))
+    {
+        // Find the macro's pattern
+        uint32_t old_offset = offset;
+        offset = (match_str.data - regex) + match_str.length;
+        const char* macro_pattern = macro_engine_get_macro(self, match_str.data + 1, match_str.length - 2);
+        if (macro_pattern == NULL)
+        {
+            // Pattern not found, don't try to expand this
+            continue;
+        }
+
+        if (expanded_pattern)
+        {
+            char* old_pattern = expanded_pattern;
+            expanded_pattern = NULL;
+            asprintf(&expanded_pattern, "%s%.*s%s",
+                     old_pattern,
+                     (int)(match_str.data - regex) - old_offset, regex + old_offset,
+                     macro_pattern);
+            free(old_pattern);
+        }
+        else
+        {
+            asprintf(&expanded_pattern, "%.*s%s",
+                    (int)(match_str.data - regex) - old_offset, regex + old_offset,
+                    macro_pattern);
+        }
+    }
+
+    // Add the rest of the non-matched regex string
+    if (expanded_pattern)
+    {
+        char* old_pattern = expanded_pattern;
+        expanded_pattern = NULL;
+        asprintf(&expanded_pattern, "%s%s", old_pattern, input_str.data + offset);
+        free(old_pattern);
+        return expanded_pattern;
+    }
+
+    // We didn't expand anything, simply dup the input
+    return strdup(regex);
+}
+
+void macro_engine_register(MacroEngine* self, const char* name, const char* regex)
+{
+    Macro* item = malloc(sizeof(Macro));
+
+    // Recursively expand this macro
+    item->expanded_regex = regex_expand(self, regex);
+    item->name = strdup(name);
+
+    item->next = self->head;
+    self->head = item;
+}
+
+int regex_verify(MacroEngine* self, const char* regex)
+{
+    // Check that this pattern compiles
+    cre2_regexp_t* rex = cre2_new(regex, (int)strlen(regex), self->opts);
+    if (!regex)
+    {
+        fprintf(stderr, "Failed to allocate memory for regex '%s'\n", regex);
+        return 0;
+    }
+
+    if (cre2_error_code(rex))
+    {
+        cre2_delete(rex);
+        return 0;
+    }
+
+    cre2_delete(rex);
+    return 1;
+}

--- a/src/codegen/regex.h
+++ b/src/codegen/regex.h
@@ -1,0 +1,33 @@
+//
+// Created by tumbar on 1/16/21.
+//
+
+#ifndef NEOAST_REGEX_H
+#define NEOAST_REGEX_H
+#include <cre2.h>
+
+typedef struct MacroEngine_prv MacroEngine;
+typedef struct Macro_prv Macro;
+
+struct Macro_prv
+{
+    char* name;
+    char* expanded_regex;
+
+    Macro* next;
+};
+
+struct MacroEngine_prv
+{
+    Macro* head;
+    cre2_regexp_t* macro_pattern;
+    cre2_options_t* opts;
+};
+
+MacroEngine* macro_engine_init();
+void macro_engine_free(MacroEngine* self);
+void macro_engine_register(MacroEngine* self, const char* name, const char* regex);
+char* regex_expand(MacroEngine* self, const char* regex);
+int regex_verify(MacroEngine* self, const char* regex);
+
+#endif //NEOAST_REGEX_H

--- a/test/input/calculator.y
+++ b/test/input/calculator.y
@@ -46,13 +46,13 @@
 // Test lex rule comment
 "[ ]+"         {return -1;}
 "[0-9]+"       {yyval->number = strtod(yytext, NULL); return TOK_N;}
-"\\+"          {return TOK_PLUS;}
-"\\-"          {return TOK_MINUS;}
-"\\/"          {return TOK_SLASH;}
-"\\*"          {return TOK_STAR;}
-"\\^"          {return TOK_CARET;}
-"\\("          {return TOK_P_OPEN;}
-"\\)"          {return TOK_P_CLOSE;}
+"\+"          {return TOK_PLUS;}
+"\-"          {return TOK_MINUS;}
+"\/"          {return TOK_SLASH;}
+"\*"          {return TOK_STAR;}
+"\^"          {return TOK_CARET;}
+"\("          {return TOK_P_OPEN;}
+"\)"          {return TOK_P_CLOSE;}
 
 
 /*

--- a/test/input/calculator_ascii.y
+++ b/test/input/calculator_ascii.y
@@ -42,13 +42,13 @@
 // Test lex rule comment
 "[ ]+"         {return -1;}
 "[0-9]+"       {yyval->number = strtod(yytext, NULL); return TOK_N;}
-"\\+"          {return '+';}
-"\\-"          {return '-';}
-"\\/"          {return '/';}
-"\\*"          {return '*';}
-"\\^"          {return '^';}
-"\\("          {return '(';}
-"\\)"          {return ')';}
+"\+"          {return '+';}
+"\-"          {return '-';}
+"\/"          {return '/';}
+"\*"          {return '*';}
+"\^"          {return '^';}
+"\("          {return '(';}
+"\)"          {return ')';}
 
 ==
 


### PR DESCRIPTION
  - Expands regex into a character table
  - No more need to manually escape unsafe C-characters
      - "\\"" is still required
  - Regular expressions are checked in the codegen step

Closes #25
Closes #15 