### PR TITLE
Use ascii character for token name

### DIFF
--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -895,7 +895,15 @@ int codegen_write(const struct File* self, FILE* fp)
     fputs("static const\nchar* token_names[] = {\n", fp);
     for (int i = 0; i < token_n - 1; i++)
     {
-        fprintf(fp, "        \"%s\",\n", tokens[i]);
+        if (strncmp(tokens[i], "ASCII_CHAR_0x", 13) == 0)
+        {
+            uint8_t c = strtoul(&tokens[i][13], NULL, 16);
+            fprintf(fp, "        \"%c\",\n", c);
+        }
+        else
+        {
+            fprintf(fp, "        \"%s\",\n", tokens[i]);
+        }
     }
     fputs("};\n\n", fp);
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -18,7 +18,7 @@ int32_t lexer_fill_table(const char* input, size_t len, const GrammarParser* par
     {
         if (buf->token_table[i] == -1)
         {
-            fprintf(stderr, "Invalid character near '%.*s' (state '%d')\n",
+            fprintf(stderr, "Unmatched token near '%.*s' (state '%d')\n",
                     (uint32_t)(strchr(&input[offset - 1], '\n') - &input[offset - 1]),
                     &input[offset - 1], STACK_PEEK(buf->lexing_state_stack));
             return -1;

--- a/src/lr.c
+++ b/src/lr.c
@@ -93,8 +93,8 @@ void lr_parse_error(const uint32_t* parsing_table,
     const char* current_token = token_names[error_tok];
     const char* prev_token = token_names[prev_tok];
 
-    fprintf(stderr, "Invalid syntax: unexpected token '%s' after '%s' (state %d)\n",
-            current_token, prev_token, current_state);
+    fprintf(stderr, "Invalid syntax: unexpected token '%s' [%d] after '%s' [%d] (state %d)\n",
+            current_token, error_tok, prev_token, prev_tok, current_state);
     fprintf(stderr, "Expected one of: ");
 
     uint32_t index_off = current_state * tok_n;
@@ -152,7 +152,7 @@ int32_t parser_parse_lr(
                                         table_value & TOK_MASK,
                                         buffers->token_table, buffers->value_table, buffers->val_s,
                                         &dest_idx);
-            prev_tok = parser->grammar_rules[table_value & TOK_MASK].token;
+            prev_tok = parser->grammar_rules[table_value & TOK_MASK].token - ASCII_MAX;
         } else if (table_value & TOK_ACCEPT_MASK)
         {
             return dest_idx;


### PR DESCRIPTION
Name a token `A` instead of `ASCII_CHAR_0x65`
Also fixes bug in prev token naming