### PR TITLE
Improved naming convention for grammar and lexer rules

### DIFF
--- a/include/neoast.h
+++ b/include/neoast.h
@@ -95,6 +95,7 @@ struct ParserBuffers_prv
     ParsingStack* lexing_state_stack;
     ParsingStack* parsing_stack;
     char* text_buffer;
+    uint32_t max_token_length;
     uint32_t val_s;
     uint32_t table_n;
 };

--- a/src/codegen/regex.c
+++ b/src/codegen/regex.c
@@ -18,7 +18,7 @@ MacroEngine* macro_engine_init()
 
     const char* pattern = "\\{[A-z][A-z0-9_]*\\}";
 
-    self->macro_pattern = cre2_new(pattern, strlen(pattern), self->opts);
+    self->macro_pattern = cre2_new(pattern, (int)strlen(pattern), self->opts);
     assert(self->macro_pattern && "re2 failed to allocate memory for regex pattern");
     assert(!cre2_error_code(self->macro_pattern) && "Failed to build macro");
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -53,7 +53,7 @@ int lex_next(const char* input, const GrammarParser* parser, const ParserBuffers
 
             if (rule->expr)
             {
-                if (match.length < 1024)
+                if (match.length < buf->max_token_length)
                 {
                     memcpy(buf->text_buffer, input + *offset, match.length);
                     buf->text_buffer[match.length] = 0;
@@ -82,7 +82,11 @@ int lex_next(const char* input, const GrammarParser* parser, const ParserBuffers
                 if (parser->ascii_mappings && token < ASCII_MAX)
                 {
                     int32_t mapping = parser->ascii_mappings[token];
-                    assert(mapping > ASCII_MAX);
+                    if (mapping <= ASCII_MAX)
+                    {
+                        fprintf(stderr, "Token '%c' needs to be explicitly defined\n", token);
+                        exit(1);
+                    }
                     return mapping - ASCII_MAX;
                 }
                 else if (!parser->ascii_mappings)

--- a/src/lr.c
+++ b/src/lr.c
@@ -148,6 +148,7 @@ int32_t parser_parse_lr(
         } else if (table_value & TOK_REDUCE_MASK)
         {
             // Reduce this rule
+            printf("REDUCE %02d\n", table_value & TOK_MASK);
             current_state = g_lr_reduce(parser, buffers->parsing_stack, parsing_table,
                                         table_value & TOK_MASK,
                                         buffers->token_table, buffers->value_table, buffers->val_s,

--- a/src/lr.c
+++ b/src/lr.c
@@ -148,7 +148,6 @@ int32_t parser_parse_lr(
         } else if (table_value & TOK_REDUCE_MASK)
         {
             // Reduce this rule
-            printf("REDUCE %02d\n", table_value & TOK_MASK);
             current_state = g_lr_reduce(parser, buffers->parsing_stack, parsing_table,
                                         table_value & TOK_MASK,
                                         buffers->token_table, buffers->value_table, buffers->val_s,

--- a/src/parser.c
+++ b/src/parser.c
@@ -64,6 +64,7 @@ ParserBuffers* parser_allocate_buffers(int max_lex_tokens, int max_token_len, in
     buffers->token_table = malloc(sizeof(uint32_t) * max_lex_tokens);
     buffers->value_table = malloc(val_s * max_lex_tokens);
     buffers->text_buffer = malloc(max_token_len);
+    buffers->max_token_length = max_token_len;
     buffers->val_s = val_s;
     buffers->table_n = max_lex_tokens;
 

--- a/test/lexer_test.c
+++ b/test/lexer_test.c
@@ -8,7 +8,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <lexer.h>
-#include <parser.h>
 
 #define CTEST(name) static void name(void** state)
 

--- a/test/lr_test.c
+++ b/test/lr_test.c
@@ -3,7 +3,6 @@
 //
 
 #include <lexer.h>
-#include <parser.h>
 #include <cmocka.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
```
static int32_t ll_rule_LEX_STATE_DEFAULT_01
static void gg_rule_r06
```

Closes #32