### PR TITLE
Compile neoast with PIC enabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(neoast
         ${CMAKE_CURRENT_SOURCE_DIR}/../include
         ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/cre2/src)
 target_link_libraries(neoast cre2 re2 pthread)
+target_compile_options(neoast PRIVATE -fPIC)
 
 add_subdirectory(parsergen)
 add_subdirectory(codegen)


### PR DESCRIPTION
Compiles libneoast.a with -fPIC so we can link to shared libs in Linux. MacOSX did not have a problem building because all code in MacOSX required PIC enabled. Static libs in Linux don't require this.