### PR TITLE
Support token/type destructors

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/include/neoast.h
+++ b/include/neoast.h
@@ -22,6 +22,12 @@ typedef struct GrammarState_prv GrammarState;
 typedef struct CanonicalCollection_prv CanonicalCollection;
 
 typedef void (*parser_expr) (void* dest, void** values);
+typedef int32_t (*lexer_expr) (
+        const char* lex_text,
+        void* lex_val,
+        uint32_t len,
+        ParsingStack* ll_state);
+typedef void (*parser_destructor) (void* self);
 
 enum
 {
@@ -76,6 +82,7 @@ struct GrammarParser_prv
     LexerRule* const* lexer_rules;
     const GrammarRule* grammar_rules;
     const char* const* token_names;
+    parser_destructor const* destructors;
 
     // Also number of columns
     uint32_t token_n;
@@ -99,12 +106,6 @@ struct ParserBuffers_prv
     uint32_t val_s;
     uint32_t table_n;
 };
-
-typedef int32_t (*lexer_expr) (
-        const char* lex_text,
-        void* lex_val,
-        uint32_t len,
-        ParsingStack* ll_state);
 
 struct LexerRule_prv
 {

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -23,6 +23,7 @@ typedef enum
     KEY_VAL_STATE,
     KEY_VAL_UNION,
     KEY_VAL_BOTTOM,
+    KEY_VAL_DESTRUCTOR,
 } key_val_t;
 
 enum
@@ -32,39 +33,40 @@ enum
     TOK_HEADER, // 2
     TOK_BOTTOM, // 3
     TOK_UNION, // 4
-    TOK_DELIMITER, // 5
+    TOK_DESTRUCTOR, // 5
+    TOK_DELIMITER, // 6
 
     /* Lexer tokens */
-    TOK_LEX_STATE, // 6
-    TOK_REGEX_RULE, // 7
+    TOK_LEX_STATE, // 7
+    TOK_REGEX_RULE, // 8
 
     /* Grammar tokens */
-    TOK_G_EXPR_DEF, // 8
-    TOK_G_TOK, // 9
-    TOK_G_OR, // 10
-    TOK_G_TERM, // 11
-    TOK_G_ACTION, // 12
+    TOK_G_EXPR_DEF, // 9
+    TOK_G_TOK, // 10
+    TOK_G_OR, // 11
+    TOK_G_TERM, // 12
+    TOK_G_ACTION, // 13
 
     /* Grammar rules */
-    TOK_GG_FILE, // 13
+    TOK_GG_FILE, // 14
 
     /* Header grammar */
-    TOK_GG_KEY_VALS, // 14
-    TOK_GG_HEADER, // 15
+    TOK_GG_KEY_VALS, // 15
+    TOK_GG_HEADER, // 16
 
     /* Lexing grammar */
-    TOK_GG_LEX_RULE, // 16
-    TOK_GG_LEX_RULES, // 17
+    TOK_GG_LEX_RULE, // 17
+    TOK_GG_LEX_RULES, // 18
 
     /* Grammar grammar :) */
-    TOK_GG_GRAMMARS, // 18
-    TOK_GG_GRAMMAR, // 19
-    TOK_GG_TOKENS, // 20
-    TOK_GG_SINGLE_GRAMMAR, // 21
-    TOK_GG_MULTI_GRAMMAR, // 22
+    TOK_GG_GRAMMARS, // 19
+    TOK_GG_GRAMMAR, // 20
+    TOK_GG_TOKENS, // 21
+    TOK_GG_SINGLE_GRAMMAR, // 22
+    TOK_GG_MULTI_GRAMMAR, // 23
 
     /* Artificial grammar */
-    TOK_AUGMENT, // 23
+    TOK_AUGMENT, // 24
 };
 
 enum

--- a/src/codegen/codegen_grammar.c
+++ b/src/codegen/codegen_grammar.c
@@ -185,6 +185,16 @@ static int32_t ll_type(const char* lex_text, CodegenUnion* lex_val)
                                      strndup(type_start + 1, type_end - type_start - 1));
     return TOK_OPTION;
 }
+static int32_t ll_destructor(const char* lex_text, CodegenUnion* lex_val)
+{
+    const char* type_start = strchr(lex_text + 5, '<');
+    const char* type_end = strchr(type_start, '>');
+
+    lex_val->key_val = key_val_build(KEY_VAL_DESTRUCTOR,
+                                     strndup(type_start + 1, type_end - type_start - 1),
+                                     NULL);
+    return TOK_DESTRUCTOR;
+}
 static int32_t ll_token_with_type(const char* lex_text, CodegenUnion* lex_val)
 {
     const char* type_start = strchr(lex_text + 6, '<');
@@ -455,6 +465,7 @@ static LexerRule ll_rules_s0[] = {
         {.regex_raw = "%top", .tok = TOK_HEADER},
         {.regex_raw = "%bottom", .tok = TOK_BOTTOM},
         {.regex_raw = "%union", .tok = TOK_UNION},
+        {.regex_raw = "%destructor" WS_OPT "<" ID_X ">", .expr = (lexer_expr) ll_destructor},
         {.regex_raw = "{", .expr = ll_match_brace},
         {.regex_raw = "\\+" ID_X WS_X "[^\n]+", .expr = (lexer_expr) ll_macro},
 };
@@ -538,6 +549,7 @@ const uint32_t grammars[][7] = {
         {TOK_HEADER, TOK_G_ACTION},
         {TOK_UNION, TOK_G_ACTION},
         {TOK_BOTTOM, TOK_G_ACTION},
+        {TOK_DESTRUCTOR, TOK_G_ACTION},
 
         /* TOK_GG_HEADER */
         {TOK_GG_KEY_VALS},
@@ -589,6 +601,11 @@ static void gg_build_union(CodegenUnion* dest, CodegenUnion* args)
 static void gg_build_bottom(CodegenUnion* dest, CodegenUnion* args)
 {
     dest->key_val = key_val_build(KEY_VAL_BOTTOM, NULL, args[1].string);
+}
+static void gg_build_destructor(CodegenUnion* dest, CodegenUnion* args)
+{
+    dest->key_val = args[0].key_val;
+    dest->key_val->value = args[1].string;
 }
 static void gg_build_l_rule_1(CodegenUnion* dest, CodegenUnion* args)
 {
@@ -662,22 +679,23 @@ static const GrammarRule gg_rules[] = {
         {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[2],        .expr = (parser_expr) gg_build_header},
         {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[3],        .expr = (parser_expr) gg_build_union},
         {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[4],        .expr = (parser_expr) gg_build_bottom},
-        {.token=TOK_GG_HEADER, .tok_n=1, .grammar=grammars[5]},
-        {.token=TOK_GG_HEADER, .tok_n=2, .grammar=grammars[6],          .expr = (parser_expr) gg_key_val_add_next},
-        {.token=TOK_GG_LEX_RULE, .tok_n=2, .grammar=grammars[7],        .expr = (parser_expr) gg_build_l_rule_1},
-        {.token=TOK_GG_LEX_RULES, .tok_n=1, .grammar=grammars[8]},
-        {.token=TOK_GG_LEX_RULES, .tok_n=2, .grammar=grammars[9],       .expr = (parser_expr) gg_build_l_rule_2},
-        {.token=TOK_GG_LEX_RULES, .tok_n=2, .grammar=grammars[10],       .expr = (parser_expr) gg_build_l_rule_3},
-        {.token=TOK_GG_TOKENS, .tok_n=1, .grammar=grammars[11]},
-        {.token=TOK_GG_TOKENS, .tok_n=2, .grammar=grammars[12],         .expr = (parser_expr) gg_build_tok},
-        {.token=TOK_GG_SINGLE_GRAMMAR, .tok_n=2, .grammar=grammars[13], .expr = (parser_expr) gg_build_single},
-        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=1, .grammar=grammars[14]},
-        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=3, .grammar=grammars[15],  .expr = (parser_expr) gg_build_multi},
-        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=1, .grammar=grammars[16],  .expr = (parser_expr) gg_build_multi_empty},
-        {.token=TOK_GG_GRAMMAR, .tok_n=3, .grammar=grammars[17],        .expr = (parser_expr) gg_build_grammar},
-        {.token=TOK_GG_GRAMMARS, .tok_n=1, .grammar=grammars[18]},
-        {.token=TOK_GG_GRAMMARS, .tok_n=2, .grammar=grammars[19],       .expr = (parser_expr) gg_build_grammars},
-        {.token=TOK_GG_FILE, .tok_n=7, .grammar=grammars[20],           .expr = (parser_expr) gg_build_file},
+        {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[5],        .expr = (parser_expr) gg_build_destructor},
+        {.token=TOK_GG_HEADER, .tok_n=1, .grammar=grammars[6]},
+        {.token=TOK_GG_HEADER, .tok_n=2, .grammar=grammars[7],          .expr = (parser_expr) gg_key_val_add_next},
+        {.token=TOK_GG_LEX_RULE, .tok_n=2, .grammar=grammars[8],        .expr = (parser_expr) gg_build_l_rule_1},
+        {.token=TOK_GG_LEX_RULES, .tok_n=1, .grammar=grammars[9]},
+        {.token=TOK_GG_LEX_RULES, .tok_n=2, .grammar=grammars[10],       .expr = (parser_expr) gg_build_l_rule_2},
+        {.token=TOK_GG_LEX_RULES, .tok_n=2, .grammar=grammars[11],       .expr = (parser_expr) gg_build_l_rule_3},
+        {.token=TOK_GG_TOKENS, .tok_n=1, .grammar=grammars[12]},
+        {.token=TOK_GG_TOKENS, .tok_n=2, .grammar=grammars[13],         .expr = (parser_expr) gg_build_tok},
+        {.token=TOK_GG_SINGLE_GRAMMAR, .tok_n=2, .grammar=grammars[14], .expr = (parser_expr) gg_build_single},
+        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=1, .grammar=grammars[15]},
+        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=3, .grammar=grammars[16],  .expr = (parser_expr) gg_build_multi},
+        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=1, .grammar=grammars[17],  .expr = (parser_expr) gg_build_multi_empty},
+        {.token=TOK_GG_GRAMMAR, .tok_n=3, .grammar=grammars[18],        .expr = (parser_expr) gg_build_grammar},
+        {.token=TOK_GG_GRAMMARS, .tok_n=1, .grammar=grammars[19]},
+        {.token=TOK_GG_GRAMMARS, .tok_n=2, .grammar=grammars[20],       .expr = (parser_expr) gg_build_grammars},
+        {.token=TOK_GG_FILE, .tok_n=7, .grammar=grammars[21],           .expr = (parser_expr) gg_build_file},
 };
 
 uint8_t precedence_table[TOK_AUGMENT] = {0};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_mocked_test(tablegen_C
 
 BuildParser(calculator_parser input/calculator.y)
 BuildParser(calculator_ascii_parser input/calculator_ascii.y)
+BuildParser(simple_ast_parser input/simple_ast.y)
 add_mocked_test(integration_C
         SOURCES
         input/calculator.y
@@ -33,6 +34,7 @@ add_mocked_test(integration_C
         integration_test.c
         ${calculator_parser_OUTPUT}
         ${calculator_ascii_parser_OUTPUT}
+        ${simple_ast_parser_OUTPUT}
         LINK_LIBRARIES neoast m
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         ENVIRONMENT ${EXEC_ENV}

--- a/test/input/calculator.y
+++ b/test/input/calculator.y
@@ -8,7 +8,6 @@
 
 // This is default, just want to test the parser
 %option parser_type="LALR(1)"
-//%option disable_locks="TRUE"
 %option debug_table="TRUE"
 %option debug_ids="$d+-/*^()ES"
 %option prefix="calc"

--- a/test/input/simple_ast.y
+++ b/test/input/simple_ast.y
@@ -1,0 +1,135 @@
+%top {
+#include <stdlib.h>
+
+typedef enum {
+    USE_OP_DISABLE, //!< !
+    USE_OP_ENABLE, //!< ?
+    USE_OP_LEAST_ONE, //!< ||
+    USE_OP_EXACT_ONE, //!< ^^
+    USE_OP_MOST_ONE, //!< ??
+} use_operator_t;
+
+typedef enum {
+    ATOM_DEFAULT_NONE, //!< use
+    ATOM_DEFAULT_ON, //!< use(+)
+    ATOM_DEFAULT_OFF, //!< use(-)
+} atom_use_default_t;
+
+typedef struct RequiredUse_prv RequiredUse;
+struct RequiredUse_prv {
+    char* target;
+    use_operator_t operator;
+    RequiredUse* depend;
+    RequiredUse* next;
+};
+
+void required_use_stmt_free(RequiredUse* self)
+{
+    if (!self) return;
+
+    required_use_stmt_free(self->depend);
+    required_use_stmt_free(self->next);
+
+    free(self->target);
+    free(self);
+}
+}
+
+// This is default, just want to test the parser
+%option parser_type="LALR(1)"
+//%option disable_locks="TRUE"
+%option debug_table="TRUE"
+%option prefix="required_use"
+
+%union {
+    char* identifier;
+    atom_use_default_t use_default;
+    RequiredUse* required_use;
+    struct {
+        char* target;
+        use_operator_t operator;
+    } use_select;
+}
+
+%token <identifier> IDENTIFIER
+%token <use_default> USE_DEFAULT
+%token <use_select> USESELECT
+
+%type <required_use> required_use_expr
+%type <required_use> required_use_single
+%type <use_select> depend_expr_sel
+%type <use_select> use_expr
+
+%start<required_use> program_required_use
+%type <required_use> program_required_use
+
+%token '!'
+%token '?'
+%token '('
+%token ')'
+
+%option debug_ids="$ids!?()ESDRP"
+
+%destructor <identifier> { free($$); }
+%destructor <use_select> { if($$.target) free($$.target); }
+%destructor <required_use> { required_use_stmt_free($$); }
+
+
++identifier      [A-Za-z_0-9][A-Za-z_0-9\-\+]*
+
+==
+
+"[\n]"                  {}
+"[ \t\r\\]+"            {/* skip */}
+"\?\?"                  {yyval->use_select.target = NULL; yyval->use_select.operator = USE_OP_MOST_ONE; return USESELECT;}
+"\|\|"                  {yyval->use_select.target = NULL; yyval->use_select.operator = USE_OP_LEAST_ONE; return USESELECT;}
+"\^\^"                  {yyval->use_select.target = NULL; yyval->use_select.operator = USE_OP_EXACT_ONE; return USESELECT;}
+"\(\+\)"                {yyval->use_default = ATOM_DEFAULT_ON; return USE_DEFAULT;}
+"\(\-\)"                {yyval->use_default = ATOM_DEFAULT_OFF; return USE_DEFAULT;}
+"!"                     {return '!';}
+"\?"                    {return '?';}
+"\("                    {return '(';}
+"\)"                    {return ')';}
+"{identifier}"          {
+                            yyval->identifier = strdup(yytext);
+                            return IDENTIFIER;
+                        }
+
+==
+
+%%
+
+program_required_use: required_use_expr   {$$ = $1;}
+            |                             {$$ = NULL;}
+            ;
+
+required_use_expr   : required_use_single                         {$$ = $1;}
+                    | required_use_single required_use_expr       {$$ = $1; $$->next = $2;}
+                    ;
+
+required_use_single : use_expr                                      {
+                                                                        $$ = malloc(sizeof(RequiredUse));
+                                                                        $$->target = $1.target;
+                                                                        $$->operator = $1.operator;
+                                                                        $$->depend = NULL;
+                                                                        $$->next = NULL;
+                                                                    }
+                    | depend_expr_sel '(' required_use_expr ')'     {
+                                                                        $$ = malloc(sizeof(RequiredUse));
+                                                                        $$->target = $1.target;
+                                                                        $$->operator = $1.operator;
+                                                                        $$->depend = $3;
+                                                                        $$->next = NULL;
+                                                                    }
+                    | '(' required_use_expr ')'                   {$$ = $2;}
+                    ;
+
+depend_expr_sel : use_expr '?'       {$$ = $1;}
+                | USESELECT          {$$ = $1;}
+                ;
+
+use_expr     : '!' IDENTIFIER        {$$.target = $2; $$.operator = USE_OP_DISABLE;}
+             | IDENTIFIER            {$$.target = $1; $$.operator = USE_OP_ENABLE;}
+             ;
+
+%%


### PR DESCRIPTION
```
%union {
    void* some_pointer_to_free;
}

%destructor <some_pointer_to_free> {my_free_function($$);}

%token <some_pointer_to_free> TOK_1
%token <some_pointer_to_free> TOK_2
```

Both `TOK_1` and `TOK_2` will be freed by this destructor if its a token left in the table when an error is encountered.

Closes #9