### PR TITLE
Option to match the longest lexer rule

### DIFF
--- a/include/neoast.h
+++ b/include/neoast.h
@@ -14,6 +14,8 @@
 #define NEOAST_STACK_POP(stack) (stack)->data[--((stack)->pos)]
 #define NEOAST_STACK_PEEK(stack) (stack)->data[(stack)->pos - 1]
 
+#define NEOAST_COMPILE_ASSERT(assertion, name) extern int name ## _gbl_assertion_compile___[(assertion) ? 1 : -1]
+
 typedef struct LexerRule_prv LexerRule;
 typedef struct GrammarParser_prv GrammarParser;
 typedef struct GrammarRule_prv GrammarRule;
@@ -61,6 +63,11 @@ enum
     ),
 };
 
+typedef enum
+{
+    LEXER_OPT_LONGEST_MATCH = 1 << 0,
+} lexer_option_t;
+
 enum
 {
     PRECEDENCE_NONE,
@@ -91,6 +98,7 @@ struct GrammarParser_prv
     // Also number of columns
     uint32_t token_n;
     uint32_t action_token_n;
+    lexer_option_t lexer_opts;
 };
 
 struct ParsingStack_prv

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -34,6 +34,8 @@ struct Options {
     unsigned long max_lex_tokens;
     unsigned long max_token_len;
     unsigned long max_lex_state_depth;
+
+    lexer_option_t lexer_opts;
 };
 
 static inline
@@ -553,6 +555,10 @@ static void codegen_handle_option(
     else if (strcmp(option->key, "max_lex_state_depth") == 0)
     {
         self->max_lex_state_depth = strtoul(option->value, NULL, 0);
+    }
+    else if (strcmp(option->key, "lex_match_longest") == 0)
+    {
+        self->lexer_opts |= codegen_parse_bool(option->value) ? LEXER_OPT_LONGEST_MATCH : 0;
     }
     else
     {

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -69,6 +69,8 @@ enum
     TOK_AUGMENT, // 24
 };
 
+NEOAST_COMPILE_ASSERT(TOK_AUGMENT == 24, assert_token_length);
+
 enum
 {
     LEX_STATE_LEXER_RULES = 1,

--- a/src/codegen/codegen_grammar.c
+++ b/src/codegen/codegen_grammar.c
@@ -4,7 +4,6 @@
 
 #include "lexer.h"
 #include "codegen.h"
-#include <parser.h>
 #include <string.h>
 #include <stdlib.h>
 #include <parsergen/canonical_collection.h>
@@ -19,7 +18,9 @@ const char* tok_names_errors[] = {
         "eof",
         "option",
         "header",
+        "bottom",
         "union",
+        "destructor",
         "delimiter",
         "lex_state",
         "regex",
@@ -112,10 +113,14 @@ static int32_t ll_option(const char* lex_text, CodegenUnion* lex_val)
 
     return TOK_OPTION;
 }
-static int32_t ll_macro(const char* lex_text, CodegenUnion* lex_val)
+static int32_t ll_macro(const char* lex_text, CodegenUnion* lex_val, uint32_t len)
 {
     // Find the white space delimiter
-    char* split = strchr(lex_text + 1, ' ');
+    const char* split = strchr(lex_text + 1, ' ');
+    if (!split)
+    {
+        split = lex_text + len;
+    }
     char* key = strndup(lex_text + 1, split - lex_text - 1);
 
     // Find the start of the regex rule
@@ -711,6 +716,7 @@ int gen_parser_init(GrammarParser* self)
     self->token_n = TOK_AUGMENT;
     self->token_names = tok_names_errors;
     self->ascii_mappings = NULL;
+    self->lexer_opts = 0;
 
     precedence_table[TOK_G_OR] = PRECEDENCE_LEFT;
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -4,7 +4,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <assert.h>
 #include "lexer.h"
 #include "parser.h"
 
@@ -31,51 +30,77 @@ int32_t lexer_fill_table(const char* input, size_t len, const GrammarParser* par
     return i;
 }
 
-int lex_next(const char* input, const GrammarParser* parser, const ParserBuffers* buf, void* lval, uint32_t len, uint32_t* offset)
+int32_t
+lex_next(const char* input,
+         const GrammarParser* parser,
+         const ParserBuffers* buf,
+         void* lval,
+         uint32_t len,
+         uint32_t* offset)
 {
-    if (*offset >= len)
-        return 0;
-
-    cre2_string_t match;
-    LexerRule* rule;
-
-    int i = 0;
-    uint32_t state_index = NEOAST_STACK_PEEK(buf->lexing_state_stack);
-    while(i < parser->lex_n[state_index])
+    while (1) // while tokens are being skipped
     {
-        rule = &parser->lexer_rules[state_index][i++];
+        if (*offset >= len)
+        {
+            return 0;
+        }
 
-        if (cre2_match(rule->regex, input, len,
-                        *offset, len, CRE2_ANCHOR_START,
-                        &match, 1))
+        uint32_t i = 0;
+        int32_t longest_match = -1;
+        uint32_t longest_match_length = 0;
+        uint32_t state_index = NEOAST_STACK_PEEK(buf->lexing_state_stack);
+        while(i < parser->lex_n[state_index])
+        {
+            cre2_string_t match;
+            LexerRule* rule = &parser->lexer_rules[state_index][i];
+
+            if (cre2_match(rule->regex, input, len,
+                           *offset, len, CRE2_ANCHOR_START,
+                           &match, 1))
+            {
+                if (match.length > longest_match_length)
+                {
+                    longest_match = i;
+                    longest_match_length = match.length;
+                }
+
+                if (!(parser->lexer_opts & LEXER_OPT_LONGEST_MATCH))
+                {
+                    // Use the first match
+                    break;
+                }
+            }
+
+            i++;
+        }
+
+        if (longest_match >= 0)
         {
             int32_t token;
+            LexerRule* rule = &parser->lexer_rules[state_index][longest_match];
 
             if (rule->expr)
             {
-                if (match.length < buf->max_token_length)
+                if (longest_match_length < buf->max_token_length)
                 {
-                    memcpy(buf->text_buffer, input + *offset, match.length);
-                    buf->text_buffer[match.length] = 0;
-                    token = rule->expr(buf->text_buffer, lval, match.length, buf->lexing_state_stack);
-                }
-                else
+                    memcpy(buf->text_buffer, input + *offset, longest_match_length);
+                    buf->text_buffer[longest_match_length] = 0;
+                    token = rule->expr(buf->text_buffer, lval, longest_match_length, buf->lexing_state_stack);
+                } else
                 {
-                    char* m_buff = strndup(match.data, match.length);
-                    token = rule->expr(m_buff, lval, match.length, buf->lexing_state_stack);
+                    char* m_buff = strndup(input + *offset, longest_match_length);
+                    token = rule->expr(m_buff, lval, longest_match_length, buf->lexing_state_stack);
                     free(m_buff);
                 }
-            }
-            else if (rule->tok)
+            } else if (rule->tok)
             {
                 token = rule->tok;
-            }
-            else
+            } else
             {
                 token = -1; // skip
             }
 
-            *offset += match.length;
+            *offset += longest_match_length;
             if (token > 0)
             {
                 // Check if this token is an ascii character and needs to be converted
@@ -88,20 +113,20 @@ int lex_next(const char* input, const GrammarParser* parser, const ParserBuffers
                         exit(1);
                     }
                     return mapping - NEOAST_ASCII_MAX;
-                }
-                else if (!parser->ascii_mappings)
+                } else if (!parser->ascii_mappings)
                 {
                     // Ascii mappings are not defined
                     return token;
-                }
-                else
+                } else
                 {
                     return token - NEOAST_ASCII_MAX;
                 }
             }
-
-            state_index = NEOAST_STACK_PEEK(buf->lexing_state_stack);
-            i = 0;
+        }
+        else
+        {
+            // No token was matched
+            break;
         }
     }
 

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -19,7 +19,7 @@
  * @param lval destination of the lexer rule
  * @return next token in buffer
  */
-int
+int32_t
 lex_next(const char* input, const GrammarParser* parser, const ParserBuffers* buf, void* lval, unsigned int len, unsigned int* offset);
 
 /**


### PR DESCRIPTION
```
%option lex_match_longest="TRUE"
```

Use this for keywording and match identifiers with embedded keywords:

```
int integer = 0;
```

Lexes to:

```
Tokens = KEYWORD_INT ID '=' NUM_CONST ';'
Values = void "integer" void 0 void
```

Instead of:
```
KEYWORD_INT KEYWORD_INT ID '=' NUM_CONST ';'
void void "eger" void 0 void
```