### PR TITLE
Support for curly bracket embedded in string/char in action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(ENABLE_NEOAST_TESTS "Build+execute neoast's tests" OFF)
 set(ASAN_LIB "libasan.so" CACHE STRING "Path to address sanitizer library")
 set(RE2_BUILD_TESTING CACHE STRING OFF)
 
-add_compile_options(-g -fno-omit-frame-pointer)
+add_compile_options(-g -fno-omit-frame-pointer -O0)
 add_link_options(-fno-omit-frame-pointer)
 
 if (NOT "${SANITIZER}" STREQUAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,13 @@ endif()
 
 include(cmake/policy.cmake)
 
-# Unit and integration testing
-include(cmake/test.cmake)
-
 add_subdirectory(src)
 add_subdirectory(third_party)
 
 include(cmake/neoast.cmake)
 
 if (ENABLE_NEOAST_TESTS)
+    # Unit and integration testing
+    include(cmake/test.cmake)
     add_subdirectory(test)
 endif()

--- a/cmake/neoast.cmake
+++ b/cmake/neoast.cmake
@@ -3,6 +3,7 @@ function(BuildParser target input_file)
     # Link the module to the python runtime
     set(neoast_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/neoast_parser__${target}.c)
     set(${target}_OUTPUT ${neoast_OUTPUT} PARENT_SCOPE)
+    message(STATUS $<TARGET_FILE:neoast-exec> ${input_file} ${neoast_OUTPUT})
     add_custom_command(OUTPUT ${neoast_OUTPUT}
             COMMAND $<TARGET_FILE:neoast-exec>
             ARGS ${input_file} ${neoast_OUTPUT}

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -1,6 +1,6 @@
 function(setup_cmocka)
-    include(${CMAKE_SOURCE_DIR}/third_party/cmocka/cmake/Modules/AddCMockaTest.cmake)
-    include(${CMAKE_SOURCE_DIR}/cmake/AddMockedTest.cmake)
+    include(${PROJECT_SOURCE_DIR}/third_party/cmocka/cmake/Modules/AddCMockaTest.cmake)
+    include(${PROJECT_SOURCE_DIR}/cmake/AddMockedTest.cmake)
 endfunction()
 
 setup_cmocka()

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -154,6 +154,7 @@ int get_named_token(const char* token_name, const char* const* tokens, uint32_t 
     }
 
     fprintf(stderr, "Invalid token name '%s'\n", token_name);
+    exit(2);
     return -1;
 }
 
@@ -958,7 +959,12 @@ int codegen_write(const struct File* self, FILE* fp)
             for (struct Token* tok_iter = rule_single_iter->tokens; tok_iter; tok_iter = tok_iter->next)
             {
                 grammar_table[grammar_tok_offset_c] = codegen_index(tokens, tok_iter->name, token_n) + NEOAST_ASCII_MAX;
-                assert(grammar_table[grammar_tok_offset_c] != -1 && "Invalid token name");
+                if (grammar_table[grammar_tok_offset_c] == -1)
+                {
+                    fprintf(stderr, "Invalid token name in grammar '%s'\n",
+                            tok_iter->name);
+                    exit(2);
+                }
                 grammar_tok_offset_c++;
                 gg_tok_n++;
             }
@@ -985,7 +991,10 @@ int codegen_write(const struct File* self, FILE* fp)
             .lexer_rules = ll_rules,
             .grammar_n = grammar_n,
             .grammar_rules = gg_rules,
-            .ascii_mappings = ascii_mappings,
+            .ascii_mappings = NULL, // yes we want NULL
+                                    // the intermediate parser generator will
+                                    // convert ascii characters to non ascii
+                                    // mapped tokens
     };
 
     // Dump parser instantiation

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -991,10 +991,7 @@ int codegen_write(const struct File* self, FILE* fp)
             .lexer_rules = ll_rules,
             .grammar_n = grammar_n,
             .grammar_rules = gg_rules,
-            .ascii_mappings = NULL, // yes we want NULL
-                                    // the intermediate parser generator will
-                                    // convert ascii characters to non ascii
-                                    // mapped tokens
+            .ascii_mappings = ascii_mappings,
     };
 
     // Dump parser instantiation

--- a/src/codegen/codegen_grammar.c
+++ b/src/codegen/codegen_grammar.c
@@ -15,6 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define _GNU_SOURCE
 
 #include "lexer.h"
 #include "codegen.h"
@@ -35,7 +36,7 @@ const char* tok_names_errors[] = {
         "bottom",
         "union",
         "destructor",
-        "delimiter",
+        "==",
         "lex_state",
         "regex",
         "expr_def",
@@ -127,6 +128,7 @@ static int32_t ll_option(const char* lex_text, CodegenUnion* lex_val)
 
     return TOK_OPTION;
 }
+
 static int32_t ll_macro(const char* lex_text, CodegenUnion* lex_val, uint32_t len)
 {
     // Find the white space delimiter
@@ -418,6 +420,8 @@ static int32_t ll_regex_quote(const char* lex_text, CodegenUnion* lex_val, uint3
         lex_val->string = strndup(regex_buffer.buffer, regex_buffer.n);
         free(regex_buffer.buffer);
         regex_buffer.buffer = NULL;
+        regex_buffer.s = 0;
+        regex_buffer.n = 0;
         NEOAST_STACK_POP(lexer_state);
         return TOK_REGEX_RULE;
     }
@@ -432,13 +436,13 @@ static int32_t ll_regex_add_to_buffer(const char* lex_text, void* lex_val, uint3
     (void) lex_val;
     (void) lexer_state;
 
-    if (len + regex_buffer.n >= regex_buffer.s)
+    while (len + regex_buffer.n >= regex_buffer.s)
     {
         regex_buffer.s *= 2;
         regex_buffer.buffer = realloc(regex_buffer.buffer, regex_buffer.s);
     }
 
-    strncpy(regex_buffer.buffer + regex_buffer.n, lex_text, len);
+    memcpy(regex_buffer.buffer + regex_buffer.n, lex_text, len);
     regex_buffer.n += len;
     return -1;
 }
@@ -513,9 +517,11 @@ static LexerRule ll_rules_grammar[] = {
 };
 
 static LexerRule ll_rules_match_brace[] = {
+        {.regex_raw = "'[\\x00-\\x7F]'", .expr = ll_add_to_buffer},
+        {.regex_raw = "(\"[^\"]*\")", .expr = ll_add_to_buffer},
         {.regex_raw = "}", .expr = (lexer_expr) ll_decrement_brace},
         {.regex_raw = "{", .expr = ll_increment_brace},
-        {.regex_raw = "([^}{]+)", .expr = ll_add_to_buffer},
+        {.regex_raw = "([^}{\"\']+)", .expr = ll_add_to_buffer},
 };
 
 static LexerRule  ll_rules_regex[] = {
@@ -729,6 +735,7 @@ int gen_parser_init(GrammarParser* self)
     self->action_token_n = TOK_GG_FILE;
     self->token_n = TOK_AUGMENT;
     self->token_names = tok_names_errors;
+    self->destructors = NULL;
     self->ascii_mappings = NULL;
     self->lexer_opts = 0;
 

--- a/src/codegen/codegen_grammar.c
+++ b/src/codegen/codegen_grammar.c
@@ -509,9 +509,9 @@ static LexerRule ll_rules_grammar[] = {
         {.regex_raw = "/\\*", .expr = ll_regex_enter_comment},
         {.regex_raw = "%%", .expr = (lexer_expr) ll_exit_state},
         {.regex_raw = ID_X WS_OPT ":", .expr = (lexer_expr) ll_g_rule},
+        {.regex_raw = ASCII, .expr = (lexer_expr) ll_g_tok_ascii},
         {.regex_raw = "{", .expr = (lexer_expr) ll_match_brace},
         {.regex_raw = ID_X, .expr = (lexer_expr) ll_g_tok},
-        {.regex_raw = ASCII, .expr = (lexer_expr) ll_g_tok_ascii},
         {.regex_raw = "\\|", .tok = TOK_G_OR},
         {.regex_raw = ";", .tok = TOK_G_TERM},
 };

--- a/src/codegen/regex.c
+++ b/src/codegen/regex.c
@@ -16,6 +16,8 @@
  */
 
 
+#define _GNU_SOURCE
+
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/src/lr.c
+++ b/src/lr.c
@@ -208,14 +208,16 @@ int32_t parser_parse_lr(
             // We need to free the remaining objects in this map
             parser_run_destructors(parser, buffers, i);
             return -1;
-        } else if (table_value & TOK_SHIFT_MASK)
+        }
+        else if (table_value & TOK_SHIFT_MASK)
         {
             current_state = table_value & TOK_MASK;
             NEOAST_STACK_PUSH(buffers->parsing_stack, i);
             NEOAST_STACK_PUSH(buffers->parsing_stack, current_state);
             prev_tok = tok;
             tok = buffers->token_table[++i];
-        } else if (table_value & TOK_REDUCE_MASK)
+        }
+        else if (table_value & TOK_REDUCE_MASK)
         {
             // Reduce this rule
             current_state = g_lr_reduce(parser, buffers->parsing_stack, parsing_table,
@@ -223,9 +225,10 @@ int32_t parser_parse_lr(
                                         buffers->token_table, buffers->value_table, buffers->val_s,
                                         &dest_idx);
             prev_tok = parser->grammar_rules[table_value & TOK_MASK].token - NEOAST_ASCII_MAX;
-        } else if (table_value & TOK_ACCEPT_MASK)
+        }
+        else if (table_value & TOK_ACCEPT_MASK)
         {
-            return dest_idx;
+            return (int32_t)dest_idx;
         }
     }
 }

--- a/src/parsergen/canonical_collection.c
+++ b/src/parsergen/canonical_collection.c
@@ -245,8 +245,9 @@ static void gs_apply_closure(GrammarState* self, const GrammarParser* parser)
             // rule describing this expression
             if (!expand_count)
             {
-                fprintf(stderr, "Could not find a rule to describe token '%d'\n",
-                        potential_token);
+                fprintf(stderr,
+                        "Could not find a rule to describe token '%s'\n",
+                        parser->token_names[potential_token - NEOAST_ASCII_MAX]);
                 exit(2);
             }
         }

--- a/src/parsergen/canonical_collection.c
+++ b/src/parsergen/canonical_collection.c
@@ -164,7 +164,9 @@ static void gs_apply_closure(GrammarState* self, const GrammarParser* parser)
         for (LR_1* item = self->head_item; item; item = item->next)
         {
             if (item->final_item)
+            {
                 continue;
+            }
 
             // Find if this rule can be expanded
             uint32_t potential_token = item->grammar->grammar[item->item_i];

--- a/src/parsergen/canonical_collection.c
+++ b/src/parsergen/canonical_collection.c
@@ -16,6 +16,7 @@
  */
 
 
+#include <alloca.h>
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
@@ -30,8 +31,8 @@ uint32_t token_to_index(uint32_t token, const GrammarParser* parser)
     {
         if (parser->ascii_mappings)
         {
-            fprintf(stderr, "ASCII characters are not valid grammar tokens\n");
-            abort();
+            fprintf(stderr, "ASCII is not a valid grammar token '%c'\n", token);
+            exit(2);
         }
     }
     else if (parser->ascii_mappings)
@@ -242,8 +243,9 @@ static void gs_apply_closure(GrammarState* self, const GrammarParser* parser)
             // rule describing this expression
             if (!expand_count)
             {
-                fprintf(stderr, "Could not find a rule to describe token '%d'\n", potential_token);
-                abort();
+                fprintf(stderr, "Could not find a rule to describe token '%d'\n",
+                        potential_token);
+                exit(2);
             }
         }
     }
@@ -321,7 +323,7 @@ void gs_resolve(CanonicalCollection* cc, GrammarState* state)
         state->action_states[next_token]->head_item = new_item;
     }
 
-    for (int32_t token = cc->parser->token_n - 1; token >= 0; token--)
+    for (int32_t token = (int32_t)cc->parser->token_n - 1; token >= 0; token--)
     {
         if (!state->action_states[token])
             continue;

--- a/test/input/calculator_ascii.y
+++ b/test/input/calculator_ascii.y
@@ -60,15 +60,16 @@ program: expr     {$$ = $1;}
      ;
 
 expr_first:
-    TOK_N                {$$ = $1;}
+      TOK_N                {$$ = $1;}
     | expr '/' expr        {$$ = $1 / $3;}
     | expr '*' expr        {$$ = $1 * $3;}
     | expr '^' expr        {$$ = pow($1, $3);}
     | '(' expr ')'         {$$ = $2;}
     ;
 
-expr: TOK_N                            {$$ = $1;}
-    | expr_first '+' expr_first        {$$ = $1 + $3;}
-    | expr_first '-' expr_first        {$$ = $1 - $3;}
+expr:
+      expr_first                 { $$ = $1; }
+    | expr '+' expr_first        {$$ = $1 + $3;}
+    | expr '-' expr_first        {$$ = $1 - $3;}
     ;
 %%

--- a/test/input/calculator_ascii.y
+++ b/test/input/calculator_ascii.y
@@ -65,6 +65,7 @@ expr_first:
     | expr '*' expr        {$$ = $1 * $3;}
     | expr '^' expr        {$$ = pow($1, $3);}
     | '(' expr ')'         {$$ = $2;}
+    ;
 
 expr: TOK_N                            {$$ = $1;}
     | expr_first '+' expr_first        {$$ = $1 + $3;}

--- a/test/input/calculator_ascii.y
+++ b/test/input/calculator_ascii.y
@@ -23,6 +23,7 @@
 %token ')'
 
 %type <number> expr
+%type <number> expr_first
 %type <number> program
 %start <number> program
 
@@ -58,12 +59,15 @@ program: expr     {$$ = $1;}
      |            {$$ = 0;}
      ;
 
-expr: TOK_N                {$$ = $1;}
-    | expr '+' expr        {$$ = $1 + $3;}
-    | expr '-' expr        {$$ = $1 - $3;}
+expr_first:
+    TOK_N                {$$ = $1;}
     | expr '/' expr        {$$ = $1 / $3;}
     | expr '*' expr        {$$ = $1 * $3;}
     | expr '^' expr        {$$ = pow($1, $3);}
     | '(' expr ')'         {$$ = $2;}
+
+expr: TOK_N                            {$$ = $1;}
+    | expr_first '+' expr_first        {$$ = $1 + $3;}
+    | expr_first '-' expr_first        {$$ = $1 - $3;}
     ;
 %%

--- a/test/integration_test.c
+++ b/test/integration_test.c
@@ -83,6 +83,18 @@ CTEST(test_parser_ascii)
     calc_ascii_free();
 }
 
+CTEST(test_parser_ascii_order_of_ops)
+{
+    assert_int_equal(calc_ascii_init(), 0);
+    void* buffers = calc_ascii_allocate_buffers();
+
+    const char* input = "3 + 5 * 5 + 3 * 6 + 3";
+    double result = calc_ascii_parse(buffers, input);
+    assert_double_equal(result, 3 + 5 * 5 + 3 * 6 + 3, 0.001);
+    calc_ascii_free_buffers(buffers);
+    calc_ascii_free();
+}
+
 CTEST(test_destructor)
 {
     assert_int_equal(required_use_init(), 0);


### PR DESCRIPTION
Support for `'{'` inside a lexer or grammar action.

Previous functionality would detect this as a bracket increment or decrement.
Also, correctly pass NULL as ascii_mappings in codegen.
Improve some errors.
Support order of ops in calculator test

Found while implementing #40 