### PR TITLE
Control parsing stack size

### DIFF
--- a/include/neoast.h
+++ b/include/neoast.h
@@ -151,7 +151,9 @@ void parser_free(GrammarParser* self);
 
 ParsingStack* parser_allocate_stack(size_t stack_n);
 void parser_free_stack(ParsingStack* self);
-ParserBuffers* parser_allocate_buffers(int max_lex_tokens, int max_token_len, int max_lex_state_depth, size_t val_s);
+ParserBuffers* parser_allocate_buffers(int max_lex_tokens, int max_token_len,
+                                       int max_lex_state_depth,
+                                       int parsing_stack_n, size_t val_s);
 void parser_free_buffers(ParserBuffers* self);
 void parser_reset_buffers(const ParserBuffers* self);
 

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -615,7 +615,8 @@ int codegen_write(const struct File* self, FILE* fp)
             .prefix = "neoast",
             .max_token_len = 1024,
             .max_lex_tokens = 1024,
-            .max_lex_state_depth = 16
+            .max_lex_state_depth = 16,
+            .parsing_stack_n = 1024,
     };
 
     MacroEngine* m_engine = macro_engine_init();

--- a/src/codegen/codegen_grammar.c
+++ b/src/codegen/codegen_grammar.c
@@ -752,8 +752,16 @@ int gen_parser_init(GrammarParser* self)
     CanonicalCollection* cc = canonical_collection_init(self);
     canonical_collection_resolve(cc, LALR_1);
 
-    GEN_parsing_table = canonical_collection_generate(cc, precedence_table);
+    uint8_t error;
+    GEN_parsing_table = canonical_collection_generate(cc, precedence_table, &error);
     canonical_collection_free(cc);
+
+    if (error)
+    {
+        fprintf(stderr, "Failed to generate parsing table for codegen grammar!\n");
+        free(GEN_parsing_table);
+        return 1;
+    }
 
     return 0;
 }

--- a/src/codegen/main.c
+++ b/src/codegen/main.c
@@ -57,7 +57,7 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    ParserBuffers* buf = parser_allocate_buffers(1024, 1024, 16, sizeof(CodegenUnion));
+    ParserBuffers* buf = parser_allocate_buffers(1024, 1024, 16, 1024, sizeof(CodegenUnion));
     int tok_n = lexer_fill_table(input, file_size, &parser, buf);
     if (tok_n < 0)
     {
@@ -91,12 +91,12 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    codegen_write(f, fp);
+    int error = codegen_write(f, fp);
     fclose(fp);
 
     parser_free_buffers(buf);
     parser_free(&parser);
     free(input);
     file_free(f);
-    return 0;
+    return error;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -69,11 +69,14 @@ void parser_free_stack(ParsingStack* self)
     free(self);
 }
 
-ParserBuffers* parser_allocate_buffers(int max_lex_tokens, int max_token_len, int max_lex_state_depth, size_t val_s)
+ParserBuffers* parser_allocate_buffers(int max_lex_tokens, int max_token_len,
+                                       int max_lex_state_depth,
+                                       int parsing_stack_n,
+                                       size_t val_s)
 {
     ParserBuffers* buffers = malloc(sizeof(ParserBuffers));
     buffers->lexing_state_stack = parser_allocate_stack(max_lex_state_depth);
-    buffers->parsing_stack = parser_allocate_stack(1024);
+    buffers->parsing_stack = parser_allocate_stack(parsing_stack_n);
 
     buffers->token_table = malloc(sizeof(uint32_t) * max_lex_tokens);
     buffers->value_table = malloc(val_s * max_lex_tokens);

--- a/src/parser.c
+++ b/src/parser.c
@@ -33,7 +33,7 @@ uint32_t parser_init(GrammarParser* self)
         {
             const char* pattern = self->lexer_rules[i][j].regex_raw;
             if ((self->lexer_rules[i][j].regex =
-                    cre2_new(pattern, (uint32_t)strlen(pattern), self->regex_opts)) == NULL) {
+                    cre2_new(pattern, (int32_t)strlen(pattern), self->regex_opts)) == NULL) {
                 fprintf(stderr, "Failed to compile regex \"%s\"\n", pattern);
                 error++;
             }

--- a/src/parser.h
+++ b/src/parser.h
@@ -44,7 +44,7 @@ void parser_free(GrammarParser* self);
 
 ParsingStack* parser_allocate_stack(uint64_t stack_n);
 void parser_free_stack(ParsingStack* self);
-ParserBuffers* parser_allocate_buffers(int max_lex_tokens, int max_token_len, int max_lex_state_depth, size_t val_s);
+ParserBuffers* parser_allocate_buffers(int max_lex_tokens, int max_token_len, int max_lex_state_depth, int parsing_stack_n, size_t val_s);
 void parser_free_buffers(ParserBuffers* self);
 void parser_reset_buffers(const ParserBuffers* self);
 

--- a/src/parsergen/canonical_collection.h
+++ b/src/parsergen/canonical_collection.h
@@ -52,11 +52,10 @@ struct CanonicalCollection_prv
     GrammarState** all_states;
 };
 
-uint8_t lr_1_firstof(uint8_t dest[], uint32_t token, const GrammarParser* parser);
 void lookahead_merge(uint8_t dest[], const uint8_t src[], uint32_t n);
 CanonicalCollection* canonical_collection_init(const GrammarParser* parser);
 void canonical_collection_resolve(CanonicalCollection* self, parser_t p_type);
-uint32_t* canonical_collection_generate(const CanonicalCollection* self, const uint8_t* precedence_table);
+uint32_t* canonical_collection_generate(const CanonicalCollection* self, const uint8_t* precedence_table, uint8_t* error);
 
 void canonical_collection_free(CanonicalCollection* self);
 

--- a/test/input/calculator_ascii.y
+++ b/test/input/calculator_ascii.y
@@ -68,8 +68,8 @@ expr_first:
     ;
 
 expr:
-      expr_first                 { $$ = $1; }
-    | expr '+' expr_first        {$$ = $1 + $3;}
-    | expr '-' expr_first        {$$ = $1 - $3;}
+      expr_first                { $$ = $1; }
+    | expr '+' expr             {$$ = $1 + $3;}
+    | expr '-' expr             {$$ = $1 - $3;}
     ;
 %%

--- a/test/lexer_test.c
+++ b/test/lexer_test.c
@@ -102,7 +102,7 @@ CTEST(test_lexer)
 
     CodegenUnion llval;
 
-    ParserBuffers* buf = parser_allocate_buffers(32, 32, 8, sizeof(CodegenUnion));
+    ParserBuffers* buf = parser_allocate_buffers(32, 32, 8, 1024, sizeof(CodegenUnion));
     NEOAST_STACK_PUSH(buf->lexing_state_stack, 0);
 
     uint32_t len = strlen(lexer_input);

--- a/test/lr_test.c
+++ b/test/lr_test.c
@@ -139,7 +139,7 @@ CTEST(test_parser)
                               ";";  // b
     initialize_parser();
 
-    ParserBuffers* buf = parser_allocate_buffers(32, 32, 4, sizeof(CodegenUnion));
+    ParserBuffers* buf = parser_allocate_buffers(32, 32, 4, 1024, sizeof(CodegenUnion));
 
     int tok_n = lexer_fill_table(lexer_input, strlen(lexer_input), &p, buf);
     assert_int_equal(tok_n, 5);

--- a/test/tablegen_test.c
+++ b/test/tablegen_test.c
@@ -203,7 +203,10 @@ CTEST(test_clr_1)
     CanonicalCollection* cc = canonical_collection_init(&p);
     canonical_collection_resolve(cc, CLR_1);
 
-    uint32_t* table = canonical_collection_generate(cc, precedence_table);
+    uint8_t error;
+    uint32_t* table = canonical_collection_generate(cc, precedence_table, &error);
+    assert_int_equal(error, 0);
+
     dump_table(table, cc, token_names, 0, stdout, NULL);
     canonical_collection_free(cc);
     free(table);
@@ -216,7 +219,10 @@ CTEST(test_lalr_1)
     CanonicalCollection* cc = canonical_collection_init(&p);
     canonical_collection_resolve(cc, LALR_1);
 
-    uint32_t* table = canonical_collection_generate(cc, precedence_table);
+    uint8_t error;
+    uint32_t* table = canonical_collection_generate(cc, precedence_table, &error);
+    assert_int_equal(error, 0);
+
     dump_table(table, cc, token_names, 0, stdout, NULL);
     canonical_collection_free(cc);
     free(table);
@@ -228,7 +234,7 @@ CTEST(test_lalr_1_calculator)
     const char* lexer_input = "1 + (5 * 9) + 2";
     initialize_parser();
 
-    ParserBuffers* buf = parser_allocate_buffers(32, 32, 4, sizeof(CalculatorUnion));
+    ParserBuffers* buf = parser_allocate_buffers(32, 32, 4, 1024, sizeof(CalculatorUnion));
 
     int tok_n = lexer_fill_table(lexer_input, strlen(lexer_input), &p, buf);
     assert_int_equal(tok_n, 9);
@@ -236,7 +242,9 @@ CTEST(test_lalr_1_calculator)
     CanonicalCollection* cc = canonical_collection_init(&p);
     canonical_collection_resolve(cc, LALR_1);
 
-    uint32_t* table = canonical_collection_generate(cc, precedence_table);
+    uint8_t error;
+    uint32_t* table = canonical_collection_generate(cc, precedence_table, &error);
+    assert_int_equal(error, 0);
 
     int32_t res_idx = parser_parse_lr(&p, table, buf);
 
@@ -257,7 +265,7 @@ CTEST(test_lalr_1_order_of_ops)
     const char* lexer_input = "1 + 5 * 9 + 4";
     initialize_parser();
 
-    ParserBuffers* buf = parser_allocate_buffers(32, 32, 4, sizeof(CalculatorUnion));
+    ParserBuffers* buf = parser_allocate_buffers(32, 32, 4, 1024, sizeof(CalculatorUnion));
 
     int tok_n = lexer_fill_table(lexer_input, strlen(lexer_input), &p, buf);
     assert_int_equal(tok_n, 7);
@@ -265,7 +273,9 @@ CTEST(test_lalr_1_order_of_ops)
     CanonicalCollection* cc = canonical_collection_init(&p);
     canonical_collection_resolve(cc, LALR_1);
 
-    uint32_t* table = canonical_collection_generate(cc, precedence_table);
+    uint8_t error;
+    uint32_t* table = canonical_collection_generate(cc, precedence_table, &error);
+    assert_int_equal(error, 0);
 
     int32_t res_idx = parser_parse_lr(&p, table, buf);
 
@@ -278,6 +288,9 @@ CTEST(test_lalr_1_order_of_ops)
     parser_free(&p);
 }
 
+uint8_t lr_1_firstof(uint8_t dest[],
+                     uint32_t token,
+                     const GrammarParser* parser);
 
 CTEST(test_first_of_expr)
 {


### PR DESCRIPTION
  - Ability to control the LR parsing stack size with `%option parsing_stack_size="N"`.
  - Better errors for undeclared tokens.
  - Ability to include generated `.c` file if `NEOAST_EXTERNAL_INCLUDE` is defined
    - Allows to use token definitions elsewhere
  - Actually use the correct table type  (LALR(1) vs CLR(1))