### PR TITLE
Bug fixes

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -23,7 +23,7 @@
 
 int32_t lexer_fill_table(const char* input, size_t len, const GrammarParser* parse, const ParserBuffers* buf)
 {
-    void* current_val = buf->value_table;
+    char* current_val = buf->value_table;
     int i = 0;
     NEOAST_STACK_PUSH(buf->lexing_state_stack, 0);
     uint32_t offset = 0;
@@ -34,6 +34,7 @@ int32_t lexer_fill_table(const char* input, size_t len, const GrammarParser* par
             fprintf(stderr, "Unmatched token near '%.*s' (state '%d')\n",
                     (uint32_t)(strchr(&input[offset - 1], '\n') - &input[offset - 1]),
                     &input[offset - 1], NEOAST_STACK_PEEK(buf->lexing_state_stack));
+            // TODO (free tokens)
             return -1;
         }
 
@@ -68,13 +69,13 @@ lex_next(const char* input,
             cre2_string_t match;
             LexerRule* rule = &parser->lexer_rules[state_index][i];
 
-            if (cre2_match(rule->regex, input, len,
-                           *offset, len, CRE2_ANCHOR_START,
+            if (cre2_match(rule->regex, input, (int32_t)len,
+                           (int32_t)*offset, (int32_t)len, CRE2_ANCHOR_START,
                            &match, 1))
             {
                 if (match.length > longest_match_length)
                 {
-                    longest_match = i;
+                    longest_match = (int32_t)i;
                     longest_match_length = match.length;
                 }
 
@@ -120,7 +121,7 @@ lex_next(const char* input,
                 // Check if this token is an ascii character and needs to be converted
                 if (parser->ascii_mappings && token < NEOAST_ASCII_MAX)
                 {
-                    int32_t mapping = parser->ascii_mappings[token];
+                    int32_t mapping = (int32_t)parser->ascii_mappings[token];
                     if (mapping <= NEOAST_ASCII_MAX)
                     {
                         fprintf(stderr, "Token '%c' needs to be explicitly defined\n", token);

--- a/src/lr.c
+++ b/src/lr.c
@@ -128,7 +128,7 @@ static void parser_run_destructors(
         const ParserBuffers* buffers,
         uint32_t i)
 {
-    // Tokens head of i are 'packed' and all of them need to be freed
+    // Tokens ahead of i are 'packed' and all of them need to be freed
     // Tokens behind i need to be freed based on the contents of the parsing stack
     // Tokens behind i are reduced tokens
 
@@ -138,9 +138,9 @@ static void parser_run_destructors(
         return;
     }
 
-    // First free the tokens head of i
+    // First free the tokens ahead of i
     uint32_t current_token;
-    while ((current_token = buffers->token_table[i++])) // search for EOF
+    while ((current_token = buffers->token_table[i])) // search for EOF
     {
         assert(current_token < parser->token_n);
         if (parser->destructors[current_token])
@@ -152,6 +152,8 @@ static void parser_run_destructors(
                                     buffers->val_s,
                                     i));
         }
+
+        i++;
     }
 
     // Free the reduced tokens

--- a/src/parsergen/canonical_collection.c
+++ b/src/parsergen/canonical_collection.c
@@ -144,7 +144,8 @@ uint8_t lr_1_firstof_impl(uint8_t dest[],
         // Recursive grammar rules
         // We can skip this one
         if (token_to_index(rule->grammar[0], parser) == token
-            || token == already_visited[1])
+            || token == already_visited[1]
+            || token_to_index(rule->grammar[0], parser) == already_visited[1])
         {
             continue;
         }
@@ -533,22 +534,6 @@ uint32_t* canonical_collection_generate(const CanonicalCollection* self,
                     // This is an accept
                     action_mask = TOK_ACCEPT_MASK;
                     grammar_id = 0;
-                    if (!(state->head_item == item && !item->next))
-                    {
-                        // Print the entire state for debugging
-                        for (const LR_1* iter_p = state->head_item; iter_p; iter_p = iter_p->next)
-                        {
-                            // Print the rule
-                            printf("%s: ", self->parser->token_names[token_to_index(iter_p->grammar->token, self->parser)]);
-                            for (int j = 0; j < iter_p->grammar->tok_n; j++)
-                            {
-                                printf("%s ", self->parser->token_names[token_to_index(iter_p->grammar->grammar[j], self->parser)]);
-                            }
-                            printf("\n");
-                        }
-
-                        assert(0 && "Accept state cannot have multiple rules");
-                    }
                 }
                 else
                 {


### PR DESCRIPTION
  - Don't use GCC extension for arithmetic with `void*` ptr
  - Get rid of implicit casting in lexer
  - Fixes destructors in front of reduction cursor
  - Allow multiple rules in `%start` rule
  - Better infinite recursion detection for first_of()
