### PR TITLE
Perform lexing at the same time as parsing

### DIFF
--- a/include/neoast.h
+++ b/include/neoast.h
@@ -141,7 +141,7 @@ typedef struct
 struct ParserBuffers_prv
 {
     void* value_table;                  //!< Value table
-    uint32_t* token_table;              //!< Token table
+    int32_t* token_table;               //!< Token table
     ParsingStack* lexing_state_stack;   //!< Lexer states
     ParsingStack* parsing_stack;        //!< LR parsing stack
     PositionData* position;             //!< Keeps track of cursor position
@@ -181,18 +181,11 @@ ParserBuffers* parser_allocate_buffers(int max_lex_tokens, int max_token_len,
 void parser_free_buffers(ParserBuffers* self);
 void parser_reset_buffers(const ParserBuffers* self);
 
-int32_t parser_parse_lr(
-        const GrammarParser* parser,
-        const uint32_t* parsing_table,
-        const ParserBuffers* buffers);
-#endif
-
-#ifndef NEOAST_LEXER_H
-#define NEOAST_LEXER_H
-int32_t lexer_fill_table(const char* input, size_t len, const GrammarParser* parse, const ParserBuffers* buf);
-
-int
-lex_next(const char* input, const GrammarParser* parser, const ParserBuffers* buf, void* lval, uint32_t len, uint32_t* offset);
+int32_t parser_parse_lr(const GrammarParser* parser,
+                        const uint32_t* parsing_table,
+                        const ParserBuffers* buffers,
+                        const char* input,
+                        size_t length);
 #endif
 
 #ifdef __cplusplus

--- a/src/codegen/main.c
+++ b/src/codegen/main.c
@@ -58,17 +58,8 @@ int main(int argc, const char* argv[])
     }
 
     ParserBuffers* buf = parser_allocate_buffers(1024, 1024, 16, 1024, sizeof(CodegenUnion));
-    int tok_n = lexer_fill_table(input, file_size, &parser, buf);
-    if (tok_n < 0)
-    {
-        fprintf(stderr, "Failed to lex file '%s'\n", argv[1]);
-        parser_free_buffers(buf);
-        parser_free(&parser);
-        free(input);
-        return 1;
-    }
 
-    int32_t result_idx = parser_parse_lr(&parser, GEN_parsing_table, buf);
+    int32_t result_idx = parser_parse_lr(&parser, GEN_parsing_table, buf, input, file_size);
 
     if (result_idx == -1)
     {

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -21,35 +21,11 @@
 #include "lexer.h"
 #include "parser.h"
 
-int32_t lexer_fill_table(const char* input, size_t len, const GrammarParser* parse, const ParserBuffers* buf)
-{
-    char* current_val = buf->value_table;
-    int i = 0;
-    NEOAST_STACK_PUSH(buf->lexing_state_stack, 0);
-    uint32_t offset = 0;
-    while ((buf->token_table[i] = lex_next(input, parse, buf, current_val, len, &offset)) && i < buf->table_n) // While not EOF
-    {
-        if (buf->token_table[i] == -1)
-        {
-            fprintf(stderr, "Unmatched token near '%.*s' (state '%d')\n",
-                    (uint32_t)(strchr(&input[offset - 1], '\n') - &input[offset - 1]),
-                    &input[offset - 1], NEOAST_STACK_PEEK(buf->lexing_state_stack));
-            // TODO (free tokens)
-            return -1;
-        }
-
-        current_val += buf->val_s;
-        i++;
-    }
-
-    return i;
-}
-
 int32_t
 lex_next(const char* input,
          const GrammarParser* parser,
          const ParserBuffers* buf,
-         char* lval,
+         void* lval,
          uint32_t len,
          uint32_t* offset)
 {
@@ -97,7 +73,7 @@ lex_next(const char* input,
             TokenPosition* position;
             if (parser->lexer_opts & LEXER_OPT_TOKEN_POS)
             {
-                position = (TokenPosition*) (lval + buf->union_s);
+                position = (TokenPosition*) (((char*)lval) + buf->union_s);
                 position->line = buf->position->line;
                 position->col_start = *offset - buf->position->line_start_offset + 1;
             }

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -34,21 +34,7 @@
  * @return next token in buffer
  */
 int32_t lex_next(const char* input, const GrammarParser* parser,
-                 const ParserBuffers* buf, char* lval,
+                 const ParserBuffers* buf, void* lval,
                  unsigned int len, unsigned int* offset);
-
-/**
- * Use the lexer to get every token in a string
- * We will stop parsing on the first token that is
- * not handled by a lexer rule
- * @param input buffer to parse
- * @param parser grammar parser reference
- * @param table table of tokens that we parsed (null terminated)
- * @param val_table value table
- * @param val_n offset of a value (size of value union)
- * @return number of parsed tokens
- */
-int32_t lexer_fill_table(const char* input, size_t len, const GrammarParser* parser,
-                         const ParserBuffers* buf);
 
 #endif //NEOAST_LEXER_H

--- a/src/lr.c
+++ b/src/lr.c
@@ -264,13 +264,11 @@ int32_t parser_parse_lr(const GrammarParser* parser,
                 // buffer tables. As rules reduce we reduce our footprint
                 // on the buffers.
                 assert(buffers->token_table[i] == tok);
-                lex_val = OFFSET_VOID_PTR(buffers->value_table, buffers->val_s, dest_idx + 1);
-                memcpy(lex_val,
-                       OFFSET_VOID_PTR(buffers->value_table, buffers->val_s, i),
-                       buffers->val_s);
-
+                void* dest_val = OFFSET_VOID_PTR(buffers->value_table, buffers->val_s, dest_idx + 1);
+                memcpy(dest_val, lex_val, buffers->val_s);
                 buffers->token_table[dest_idx + 1] = buffers->token_table[i];
 
+                lex_val = dest_val;
                 i = dest_idx + 1;
             }
 

--- a/src/lr.c
+++ b/src/lr.c
@@ -20,14 +20,15 @@
 #include <alloca.h>
 #include <string.h>
 #include <assert.h>
+#include "lexer.h"
 
 static inline
-void* g_table_from_matrix(void* table,
-                          size_t row, size_t col,
-                          size_t col_n, size_t s)
+const void* g_table_from_matrix(const void* table,
+                                size_t row, size_t col,
+                                size_t col_n)
 {
-    size_t off = s * ((row * col_n) + (col));
-    return ((char*) table) + off;
+    size_t off = sizeof(uint32_t) * ((row * col_n) + (col));
+    return ((const char*) table) + off;
 }
 
 static inline
@@ -36,7 +37,7 @@ uint32_t g_lr_reduce(
         ParsingStack* stack,
         const uint32_t* parsing_table,
         uint32_t reduce_rule,
-        uint32_t* token_table,
+        int32_t* token_table,
         void* val_table,
         size_t val_s,
         size_t union_s,
@@ -62,7 +63,7 @@ uint32_t g_lr_reduce(
                val_s);
     }
 
-    int result_token = (int)parser->grammar_rules[reduce_rule].token;
+    int32_t result_token = (int32_t)parser->grammar_rules[reduce_rule].token;
     if (parser->ascii_mappings)
     {
         result_token -= NEOAST_ASCII_MAX;
@@ -101,11 +102,10 @@ uint32_t g_lr_reduce(
 
     // Check the goto
     uint32_t next_state = *(uint32_t*) g_table_from_matrix(
-            (void*) parsing_table,
+            parsing_table,
             NEOAST_STACK_PEEK(stack), // Top of stack is current state
             result_token,
-            parser->token_n,
-            sizeof(uint32_t));
+            parser->token_n);
 
     next_state &= TOK_MASK;
 
@@ -142,38 +142,27 @@ void lr_parse_error(const uint32_t* parsing_table,
     fprintf(stderr, "\n");
 }
 
+void lr_lex_error(const ParserBuffers* buf,
+                  const char* input,
+                  uint32_t offset)
+{
+    fprintf(stderr, "Unmatched token near '%.*s' (state '%d')\n",
+            (uint32_t)(strchr(&input[offset - 1], '\n') - &input[offset - 1]),
+            &input[offset - 1],
+            NEOAST_STACK_PEEK(buf->lexing_state_stack));
+}
+
 static void parser_run_destructors(
         const GrammarParser* parser,
-        const ParserBuffers* buffers,
-        uint32_t i)
+        const ParserBuffers* buffers)
 {
-    // Tokens ahead of i are 'packed' and all of them need to be freed
-    // Tokens behind i need to be freed based on the contents of the parsing stack
-    // Tokens behind i are reduced tokens
-
     if (!parser->destructors)
     {
         // Destructors have not been defined
         return;
     }
 
-    // First free the tokens ahead of i
     uint32_t current_token;
-    while ((current_token = buffers->token_table[i])) // search for EOF
-    {
-        assert(current_token < parser->token_n);
-        if (parser->destructors[current_token])
-        {
-            // A destructor is defined for this token
-            // Call the destructor on this object
-            parser->destructors[current_token](
-                    OFFSET_VOID_PTR(buffers->value_table,
-                                    buffers->val_s,
-                                    i));
-        }
-
-        i++;
-    }
 
     // Free the reduced tokens
     assert(buffers->parsing_stack->pos % 2 == 1);
@@ -197,37 +186,54 @@ static void parser_run_destructors(
     }
 }
 
-int32_t parser_parse_lr(
-        const GrammarParser* parser,
-        const uint32_t* parsing_table,
-        const ParserBuffers* buffers)
+int32_t parser_parse_lr(const GrammarParser* parser,
+                        const uint32_t* parsing_table,
+                        const ParserBuffers* buffers,
+                        const char* input,
+                        size_t length)
 {
+    // Lexer states
+    uint32_t offset = 0;
+    void* lex_val = buffers->value_table;
+    NEOAST_STACK_PUSH(buffers->lexing_state_stack, 0);
+
     // Push the initial state to the stack
     uint32_t current_state = 0;
     NEOAST_STACK_PUSH(buffers->parsing_stack, current_state);
 
     uint32_t i = 0;
     uint32_t prev_tok = 0;
-    uint32_t tok = buffers->token_table[i];
+    int32_t tok = lex_next(input, parser, buffers, lex_val, length, &offset);
+    buffers->token_table[i] = tok;
+
     uint32_t dest_idx = 0; // index of the last reduction
     while (1)
     {
+        // Check for lexing error
+        if (tok < 0)
+        {
+            // TODO Enable user specified function
+            lr_lex_error(buffers, input, offset);
+            parser_run_destructors(parser, buffers);
+            return -1;
+        }
+
         uint32_t table_value = *(uint32_t*) g_table_from_matrix(
-                (void*)parsing_table,
+                parsing_table,
                 current_state,
                 tok,
-                parser->token_n,
-                sizeof(uint32_t));
+                parser->token_n);
 
         if (table_value == TOK_SYNTAX_ERROR)
         {
+            // TODO Enable user specified function
             lr_parse_error(parsing_table,
                            parser->token_names, current_state,
                            tok, prev_tok,
                            parser->token_n);
 
             // We need to free the remaining objects in this map
-            parser_run_destructors(parser, buffers, i);
+            parser_run_destructors(parser, buffers);
             return -1;
         }
         else if (table_value & TOK_SHIFT_MASK)
@@ -236,7 +242,10 @@ int32_t parser_parse_lr(
             NEOAST_STACK_PUSH(buffers->parsing_stack, i);
             NEOAST_STACK_PUSH(buffers->parsing_stack, current_state);
             prev_tok = tok;
-            tok = buffers->token_table[++i];
+
+            lex_val += buffers->val_s;
+            tok = lex_next(input, parser, buffers, lex_val, length, &offset);
+            buffers->token_table[++i] = tok;
         }
         else if (table_value & TOK_REDUCE_MASK)
         {

--- a/src/parser.h
+++ b/src/parser.h
@@ -37,7 +37,9 @@
 int32_t parser_parse_lr(
         const GrammarParser* parser,
         const uint32_t* parsing_table,
-        const ParserBuffers* buffers);
+        const ParserBuffers* buffers,
+        const char* input,
+        size_t length);
 
 uint32_t parser_init(GrammarParser* self);
 void parser_free(GrammarParser* self);

--- a/test/integration_test.c
+++ b/test/integration_test.c
@@ -106,12 +106,24 @@ CTEST(test_destructor)
     required_use_free();
 }
 
+CTEST(test_destructor_lex)
+{
+    assert_int_equal(required_use_init(), 0);
+    void* buffers = required_use_allocate_buffers();
+    void* stmt = required_use_parse(buffers, "( hello_world %%%% )");
+    assert_null(stmt);
+    required_use_stmt_free(stmt);
+    required_use_free_buffers(buffers);
+    required_use_free();
+}
+
 const static struct CMUnitTest left_scan_tests[] = {
         cmocka_unit_test(test_empty),
         cmocka_unit_test(test_parser),
         cmocka_unit_test(test_empty_ascii),
         cmocka_unit_test(test_parser_ascii),
         cmocka_unit_test(test_destructor),
+        cmocka_unit_test(test_destructor_lex),
 };
 
 int main()

--- a/test/lr_test.c
+++ b/test/lr_test.c
@@ -141,10 +141,7 @@ CTEST(test_parser)
 
     ParserBuffers* buf = parser_allocate_buffers(32, 32, 4, 1024, sizeof(CodegenUnion), sizeof(CodegenUnion));
 
-    int tok_n = lexer_fill_table(lexer_input, strlen(lexer_input), &p, buf);
-    assert_int_equal(tok_n, 5);
-
-    int32_t res_idx = parser_parse_lr(&p, lalr_table, buf);
+    int32_t res_idx = parser_parse_lr(&p, lalr_table, buf, lexer_input, strlen(lexer_input));
 
     parser_free_buffers(buf);
     parser_free(&p);

--- a/test/tablegen_test.c
+++ b/test/tablegen_test.c
@@ -236,9 +236,6 @@ CTEST(test_lalr_1_calculator)
 
     ParserBuffers* buf = parser_allocate_buffers(32, 32, 4, 1024, sizeof(CalculatorUnion), sizeof(CalculatorUnion));
 
-    int tok_n = lexer_fill_table(lexer_input, strlen(lexer_input), &p, buf);
-    assert_int_equal(tok_n, 9);
-
     CanonicalCollection* cc = canonical_collection_init(&p);
     canonical_collection_resolve(cc, LALR_1);
 
@@ -246,7 +243,7 @@ CTEST(test_lalr_1_calculator)
     uint32_t* table = canonical_collection_generate(cc, precedence_table, &error);
     assert_int_equal(error, 0);
 
-    int32_t res_idx = parser_parse_lr(&p, table, buf);
+    int32_t res_idx = parser_parse_lr(&p, table, buf, lexer_input, strlen(lexer_input));
 
     dump_table(table, cc, token_names, 0, stdout, NULL);
     assert_int_not_equal(res_idx, -1);
@@ -267,9 +264,6 @@ CTEST(test_lalr_1_order_of_ops)
 
     ParserBuffers* buf = parser_allocate_buffers(32, 32, 4, 1024, sizeof(CalculatorUnion), sizeof(CalculatorUnion));
 
-    int tok_n = lexer_fill_table(lexer_input, strlen(lexer_input), &p, buf);
-    assert_int_equal(tok_n, 7);
-
     CanonicalCollection* cc = canonical_collection_init(&p);
     canonical_collection_resolve(cc, LALR_1);
 
@@ -277,7 +271,7 @@ CTEST(test_lalr_1_order_of_ops)
     uint32_t* table = canonical_collection_generate(cc, precedence_table, &error);
     assert_int_equal(error, 0);
 
-    int32_t res_idx = parser_parse_lr(&p, table, buf);
+    int32_t res_idx = parser_parse_lr(&p, table, buf, lexer_input, strlen(lexer_input));
 
     // This parser has no order of ops
     assert_double_equal(((CalculatorUnion*)buf->value_table)[res_idx].number, (((1 + 5) * 9) + 4), 0.005);


### PR DESCRIPTION
Runs the lexing algorithm live as LR needs the tokens
  
Some advantages:
   1. We can consolidate the buffer tables during parsing so we can support infinite tokens (closes #1)
   2. Keep most of the values close together in the buffer table to better utilize cache memory
   3. Grammar actions run live meaning we can add some grammar context to lexing
   4. Simpler algorithm