### PR TITLE
Intermediate compiler compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT "${SANITIZER}" STREQUAL "")
     add_compile_options(-fsanitize=${SANITIZER})
     add_link_options(-fsanitize=${SANITIZER})
     message(STATUS "Building with -fsanitize=${SANITIZER}")
-    add_compile_options(-g -fno-omit-frame-pointer -O1)
+    add_compile_options(-g -fno-omit-frame-pointer -O0)
 endif()
 
 include(cmake/policy.cmake)

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -1,10 +1,24 @@
 add_library(neoast-codegen STATIC
-        codegen_grammar.c codegen.h
+        codegen.h
         codegen.c
-        regex.c regex.h)
-add_executable(neoast-exec main.c)
+        regex.c regex.h compiler.c compiler.h common.c)
+
+add_executable(neoast-bootstrap
+        bootstrap/codegen_grammar.c
+        bootstrap/main.c bootstrap/grammar.h)
+
+set(compiler_compiler ${CMAKE_CURRENT_BINARY_DIR}/neoast_compiler_compiler.c)
+
+add_custom_command(OUTPUT ${compiler_compiler}
+        COMMAND $<TARGET_FILE:neoast-bootstrap>
+        ARGS compiler_compiler.y ${compiler_compiler}
+        DEPENDS compiler_compiler.y neoast-bootstrap neoast-codegen
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(neoast-exec ${compiler_compiler} main.c)
 
 include_directories(neoast-codegen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../)
 
 target_link_libraries(neoast-codegen neoast neoast-parsergen neoast-util)
 target_link_libraries(neoast-exec neoast-codegen)
+target_link_libraries(neoast-bootstrap neoast-codegen)

--- a/src/codegen/bootstrap/codegen_grammar.c
+++ b/src/codegen/bootstrap/codegen_grammar.c
@@ -268,7 +268,7 @@ static int32_t ll_g_rule(const char* lex_text, CodegenUnion* lex_val)
 
 static int32_t ll_g_tok(const char* lex_text, CodegenUnion* lex_val)
 {
-    lex_val->token = build_token(NULL, lex_text);
+    lex_val->token = build_token(NULL, strdup(lex_text));
     return TOK_G_TOK;
 }
 

--- a/src/codegen/bootstrap/grammar.h
+++ b/src/codegen/bootstrap/grammar.h
@@ -1,0 +1,70 @@
+#ifndef NEOAST_GRAMMAR_H
+#define NEOAST_GRAMMAR_H
+
+enum
+{
+    // -1 = skip, 0 = EOF
+    TOK_OPTION = 1,
+    TOK_HEADER, // 2
+    TOK_BOTTOM, // 3
+    TOK_UNION, // 4
+    TOK_DESTRUCTOR, // 5
+    TOK_DELIMITER, // 6
+
+    /* Lexer tokens */
+    TOK_LEX_STATE, // 7
+    TOK_REGEX_RULE, // 8
+    TOK_END_STATE, // 9
+
+    /* Grammar tokens */
+    TOK_G_EXPR_DEF, // 10
+    TOK_G_TOK, // 11
+    TOK_G_OR, // 12
+    TOK_G_TERM, // 13
+    TOK_G_ACTION, // 14
+
+    /* Grammar rules */
+    TOK_GG_FILE, // 15
+
+    /* Header grammar */
+    TOK_GG_KEY_VALS, // 16
+    TOK_GG_HEADER, // 17
+
+    /* Lexing grammar */
+    TOK_GG_LEX_RULE, // 18
+    TOK_GG_LEX_RULES, // 19
+
+    /* Grammar grammar :) */
+    TOK_GG_GRAMMARS, // 20
+    TOK_GG_GRAMMAR, // 21
+    TOK_GG_TOKENS, // 22
+    TOK_GG_SINGLE_GRAMMAR, // 23
+    TOK_GG_MULTI_GRAMMAR, // 24
+
+    /* Artificial grammar */
+    TOK_AUGMENT, // 25
+};
+
+NEOAST_COMPILE_ASSERT(TOK_AUGMENT == 25, assert_token_length);
+
+enum
+{
+    LEX_STATE_LEXER_RULES = 1,
+    LEX_STATE_GRAMMAR_RULES,
+    LEX_STATE_MATCH_BRACE,
+    LEX_STATE_REGEX,
+    LEX_STATE_LEX_STATE,
+    LEX_STATE_COMMENT
+};
+
+typedef union {
+    struct KeyVal* key_val;
+    struct LexerRuleProto* l_rule;
+    struct Token* token;
+    struct GrammarRuleSingleProto* g_single_rule;
+    struct GrammarRuleProto* g_rule;
+    struct File* file;
+    char* string;
+} CodegenUnion;
+
+#endif //NEOAST_GRAMMAR_H

--- a/src/codegen/bootstrap/main.c
+++ b/src/codegen/bootstrap/main.c
@@ -1,0 +1,98 @@
+/* 
+ * This file is part of the Neoast framework
+ * Copyright (c) 2021 Andrei Tumbar.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <parser.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "lexer.h"
+#include "codegen/codegen.h"
+#include "grammar.h"
+
+extern uint32_t* GEN_parsing_table;
+
+int main(int argc, const char* argv[])
+{
+    if (argc != 3)
+    {
+        fprintf(stderr, "usage: %s [INPUT_FILE] [OUTPUT_FILE]\n", argv[0]);
+        return 1;
+    }
+
+    char* input;
+    FILE* fp = fopen(argv[1], "r");
+    if (!fp)
+    {
+        fprintf(stderr, "Failed to open '%s': %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+
+    fseek(fp, 0L, SEEK_END);
+    size_t file_size = ftell(fp);
+    fseek(fp, 0L, SEEK_SET);
+
+    // Read the whole file
+    input = malloc(file_size + 1);
+    size_t offset = 0;
+    while ((offset += fread(input + offset, 1, 1024, fp)) < file_size);
+    input[file_size] = 0;
+    fclose(fp);
+
+    GrammarParser parser;
+    if (gen_parser_init(&parser))
+    {
+        free(input);
+        return 1;
+    }
+
+    ParserBuffers* buf = parser_allocate_buffers(1024, 1024, 16, 1024, sizeof(CodegenUnion));
+
+    int32_t result_idx = parser_parse_lr(&parser, GEN_parsing_table, buf, input, file_size);
+
+    if (result_idx == -1)
+    {
+        fprintf(stderr, "Failed to parse file '%s'\n", argv[1]);
+        parser_free_buffers(buf);
+        parser_free(&parser);
+        free(input);
+        return 1;
+    }
+
+    struct File* f = ((CodegenUnion*)buf->value_table)[result_idx].file;
+    fp = fopen(argv[2], "w+");
+    if (!fp)
+    {
+        fprintf(stderr, "Failed to open '%s': %s\n", argv[1], strerror(errno));
+        parser_free_buffers(buf);
+        parser_free(&parser);
+        free(input);
+        file_free(f);
+        return 1;
+    }
+
+    int error = codegen_write(f, fp);
+    fclose(fp);
+
+    parser_free_buffers(buf);
+    parser_free(&parser);
+    free(input);
+    file_free(f);
+
+    return error;
+}

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -1080,7 +1080,7 @@ int codegen_write(const struct File* self, FILE* fp)
         int type_id = get_named_token(rule_iter->name, tokens, token_n);
         if (type_id < action_n)
         {
-            emit_error(&rule_iter->position, "Grammar rule defined for %%token - did mean %%type?");
+            emit_error(&rule_iter->position, "Grammar rule defined for %%token - did you mean %%type?");
             continue;
         }
 

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -161,7 +161,7 @@ const char* put_grammar_rule_arg(
         struct GrammarRuleSingleProto* self,
         const char** tokens,
         const struct KeyVal** typed_tokens,
-        const char* track_position_type,
+        const struct Options* options,
         uint32_t token_n,
         FILE* fp)
 {
@@ -212,9 +212,15 @@ const char* put_grammar_rule_arg(
 
     if (search[1] == 'p')
     {
-        if (track_position_type)
+        if (!(options->lexer_opts & LEXER_OPT_TOKEN_POS))
         {
-            fprintf(fp, "((const %s*)&args[%d].position)", track_position_type, arg_num - 1);
+            emit_error(&self->position, "Attempting to get token position without track_position=\"TRUE\"");
+            return NULL;
+        }
+
+        if (options->track_position_type)
+        {
+            fprintf(fp, "((const %s*)&args[%d].position)", options->track_position_type, arg_num - 1);
         }
         else
         {
@@ -248,7 +254,7 @@ void put_grammar_rule_action(
         struct GrammarRuleSingleProto* self,
         const char** tokens,
         const struct KeyVal** typed_tokens,
-        const char* track_position_type,
+        const struct Options* options,
         uint32_t token_n,
         uint32_t rule_n,
         FILE* fp)
@@ -283,7 +289,7 @@ void put_grammar_rule_action(
 
                 // Print the argument
                 start = put_grammar_rule_arg(search, parent, self, tokens, typed_tokens,
-                                             track_position_type, token_n, fp);
+                                             options, token_n, fp);
                 if (!start)
                 {
                     break;
@@ -1083,7 +1089,7 @@ int codegen_write(const struct File* self, FILE* fp)
              rule_single_iter = rule_single_iter->next)
         {
             put_grammar_rule_action(rule_iter, rule_single_iter, tokens, typed_tokens,
-                                    options.track_position_type,
+                                    &options,
                                     token_n, grammar_n + 1, fp);
             grammar_n++;
 

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -23,90 +23,35 @@
 
 typedef enum
 {
-    KEY_VAL_HEADER, // Key not filled
+    KEY_VAL_TOP, // Key not filled
+    KEY_VAL_BOTTOM,
     KEY_VAL_OPTION,
     KEY_VAL_TOKEN,
     KEY_VAL_TOKEN_ASCII,
     KEY_VAL_TOKEN_TYPE,
-    KEY_VAL_TOKEN_TYPE_ASCII,
     KEY_VAL_TYPE,
     KEY_VAL_LEFT,
     KEY_VAL_RIGHT,
     KEY_VAL_MACRO,
     KEY_VAL_START,
-    KEY_VAL_STATE,
     KEY_VAL_UNION,
-    KEY_VAL_BOTTOM,
     KEY_VAL_DESTRUCTOR,
 } key_val_t;
 
-enum
-{
-    // -1 = skip, 0 = EOF
-    TOK_OPTION = 1,
-    TOK_HEADER, // 2
-    TOK_BOTTOM, // 3
-    TOK_UNION, // 4
-    TOK_DESTRUCTOR, // 5
-    TOK_DELIMITER, // 6
-
-    /* Lexer tokens */
-    TOK_LEX_STATE, // 7
-    TOK_REGEX_RULE, // 8
-
-    /* Grammar tokens */
-    TOK_G_EXPR_DEF, // 9
-    TOK_G_TOK, // 10
-    TOK_G_OR, // 11
-    TOK_G_TERM, // 12
-    TOK_G_ACTION, // 13
-
-    /* Grammar rules */
-    TOK_GG_FILE, // 14
-
-    /* Header grammar */
-    TOK_GG_KEY_VALS, // 15
-    TOK_GG_HEADER, // 16
-
-    /* Lexing grammar */
-    TOK_GG_LEX_RULE, // 17
-    TOK_GG_LEX_RULES, // 18
-
-    /* Grammar grammar :) */
-    TOK_GG_GRAMMARS, // 19
-    TOK_GG_GRAMMAR, // 20
-    TOK_GG_TOKENS, // 21
-    TOK_GG_SINGLE_GRAMMAR, // 22
-    TOK_GG_MULTI_GRAMMAR, // 23
-
-    /* Artificial grammar */
-    TOK_AUGMENT, // 24
-};
-
-NEOAST_COMPILE_ASSERT(TOK_AUGMENT == 24, assert_token_length);
-
-enum
-{
-    LEX_STATE_LEXER_RULES = 1,
-    LEX_STATE_GRAMMAR_RULES,
-    LEX_STATE_MATCH_BRACE,
-    LEX_STATE_REGEX,
-    LEX_STATE_LEX_STATE,
-    LEX_STATE_COMMENT
-};
-
 struct KeyVal
 {
+    TokenPosition position;
     key_val_t type;
     char* key;
     char* value;
-    uint64_t options;
     struct KeyVal* next;
 };
 
 struct LexerRuleProto
 {
+    TokenPosition position;
     char* lexer_state; // NULL for default
+    struct LexerRuleProto* state_rules;
     char* regex;
     char* function;
     struct LexerRuleProto* next;
@@ -114,12 +59,15 @@ struct LexerRuleProto
 
 struct Token
 {
+    TokenPosition position;
     char* name;
+    char ascii;
     struct Token* next;
 };
 
 struct GrammarRuleSingleProto
 {
+    TokenPosition position;
     struct Token* tokens;
     char* function;
     struct GrammarRuleSingleProto* next;
@@ -127,6 +75,7 @@ struct GrammarRuleSingleProto
 
 struct GrammarRuleProto
 {
+    TokenPosition position;
     char* name;
     struct GrammarRuleSingleProto* rules;
     struct GrammarRuleProto* next;
@@ -139,22 +88,26 @@ struct File
     struct GrammarRuleProto* grammar_rules;
 };
 
-typedef union {
-    struct KeyVal* key_val;
-    struct LexerRuleProto* l_rule;
-    struct Token* token;
-    struct GrammarRuleSingleProto* g_single_rule;
-    struct GrammarRuleProto* g_rule;
-    struct File* file;
-    char* string;
-} CodegenUnion;
-
 int gen_parser_init(GrammarParser* self);
 int codegen_write(const struct File* self, FILE* fp);
 
+void emit_warning(const TokenPosition* position, const char* message, ...);
+void emit_error(const TokenPosition* position, const char* message, ...);
+int has_errors();
+
+struct KeyVal* key_val_build(const TokenPosition* p, key_val_t type, char* key, char* value);
+struct Token* build_token(const TokenPosition* position, const char* name);
+struct Token* build_token_ascii(const TokenPosition* position, char value);
+char* get_ascii_token_name(char value);
+char get_ascii_from_name(const char* name);
+
+void tokens_free(struct Token* self);
+void key_val_free(struct KeyVal* self);
+void lexer_rule_free(struct LexerRuleProto* self);
+void grammar_rule_single_free(struct GrammarRuleSingleProto* self);
+void grammar_rule_multi_free(struct GrammarRuleProto* self);
 void file_free(struct File* self);
 
-extern uint32_t* GEN_parsing_table;
 extern const char* tok_names_errors[];
 
 #endif //NEOAST_CODEGEN_H

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -96,7 +96,7 @@ void emit_error(const TokenPosition* position, const char* message, ...);
 int has_errors();
 
 struct KeyVal* key_val_build(const TokenPosition* p, key_val_t type, char* key, char* value);
-struct Token* build_token(const TokenPosition* position, const char* name);
+struct Token* build_token(const TokenPosition* position, char* name);
 struct Token* build_token_ascii(const TokenPosition* position, char value);
 char* get_ascii_token_name(char value);
 char get_ascii_from_name(const char* name);

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -44,6 +44,8 @@ struct KeyVal
     key_val_t type;
     char* key;
     char* value;
+
+    struct KeyVal* back;
     struct KeyVal* next;
 };
 

--- a/src/codegen/common.c
+++ b/src/codegen/common.c
@@ -22,7 +22,7 @@ struct KeyVal* key_val_build(const TokenPosition* p, key_val_t type, char* key, 
     return self;
 }
 
-struct Token* build_token(const TokenPosition* position, const char* name)
+struct Token* build_token(const TokenPosition* position, char* name)
 {
     struct Token* self = malloc(sizeof(struct Token));
     if (strncmp(name, "ASCII_CHAR_0x", 13) == 0)
@@ -36,7 +36,7 @@ struct Token* build_token(const TokenPosition* position, const char* name)
         self->position = *position;
     }
 
-    self->name = strdup(name);
+    self->name = name;
     self->next = NULL;
     self->ascii = 0;
     return self;
@@ -75,8 +75,7 @@ void tokens_free(struct Token* self)
     while (self)
     {
         next = self->next;
-        assert(self->name);
-        free(self->name);
+        if (self->name) free(self->name);
         free(self);
         self = next;
     }

--- a/src/codegen/common.c
+++ b/src/codegen/common.c
@@ -15,6 +15,7 @@ struct KeyVal* key_val_build(const TokenPosition* p, key_val_t type, char* key, 
     }
 
     self->next = NULL;
+    self->back = NULL;
     self->type = type;
     self->key = key;
     self->value = value;
@@ -84,6 +85,11 @@ void tokens_free(struct Token* self)
 void key_val_free(struct KeyVal* self)
 {
     struct KeyVal* next;
+    if (self->back)
+    {
+        self = self->back;
+    }
+
     while (self)
     {
         next = self->next;

--- a/src/codegen/common.c
+++ b/src/codegen/common.c
@@ -1,0 +1,164 @@
+#define _GNU_SOURCE
+
+#include <string.h>
+#include <assert.h>
+#include <malloc.h>
+#include <stdlib.h>
+#include "codegen.h"
+
+struct KeyVal* key_val_build(const TokenPosition* p, key_val_t type, char* key, char* value)
+{
+    struct KeyVal* self = malloc(sizeof(struct KeyVal));
+    if (p)
+    {
+        self->position = *p;
+    }
+
+    self->next = NULL;
+    self->type = type;
+    self->key = key;
+    self->value = value;
+
+    return self;
+}
+
+struct Token* build_token(const TokenPosition* position, const char* name)
+{
+    struct Token* self = malloc(sizeof(struct Token));
+    if (strncmp(name, "ASCII_CHAR_0x", 13) == 0)
+    {
+        emit_error(position, "Token name may not start with 'ASCII_CHAR_0x'");
+        return NULL;
+    }
+
+    if (position)
+    {
+        self->position = *position;
+    }
+
+    self->name = strdup(name);
+    self->next = NULL;
+    self->ascii = 0;
+    return self;
+}
+
+char* get_ascii_token_name(char value)
+{
+    char* name = NULL;
+    (void)asprintf(&name, "ASCII_CHAR_0x%02X", value);
+    return name;
+}
+
+char get_ascii_from_name(const char* name)
+{
+    assert(strncmp(name, "ASCII_CHAR_0x", 13) == 0);
+    return (char)strtoul(name + 13, NULL, 16);
+}
+
+struct Token* build_token_ascii(const TokenPosition* position, char value)
+{
+    struct Token* self = malloc(sizeof(struct Token));
+    if (position)
+    {
+        self->position = *position;
+    }
+
+    self->name = get_ascii_token_name(value);
+    self->next = NULL;
+    self->ascii = value;
+    return self;
+}
+
+void tokens_free(struct Token* self)
+{
+    struct Token* next;
+    while (self)
+    {
+        next = self->next;
+        assert(self->name);
+        free(self->name);
+        free(self);
+        self = next;
+    }
+}
+
+void key_val_free(struct KeyVal* self)
+{
+    struct KeyVal* next;
+    while (self)
+    {
+        next = self->next;
+        if (self->key) free(self->key);
+
+        assert(self->value);
+        free(self->value);
+
+        free(self);
+        self = next;
+    }
+}
+
+void lexer_rule_free(struct LexerRuleProto* self)
+{
+    struct LexerRuleProto* next;
+    while (self)
+    {
+        next = self->next;
+
+        if (self->lexer_state)
+        {
+            assert(!self->function);
+            assert(!self->regex);
+            assert(self->state_rules);
+            lexer_rule_free(self->state_rules);
+            free(self->lexer_state);
+        }
+        else
+        {
+            assert(self->function);
+            assert(self->regex);
+            assert(!self->state_rules);
+            free(self->function);
+            free(self->regex);
+        }
+
+        free(self);
+        self = next;
+    }
+}
+
+void grammar_rule_single_free(struct GrammarRuleSingleProto* self)
+{
+    struct GrammarRuleSingleProto* next;
+    while (self)
+    {
+        next = self->next;
+        assert(self->function);
+        free(self->function);
+        tokens_free(self->tokens);
+        free(self);
+        self = next;
+    }
+}
+
+void grammar_rule_multi_free(struct GrammarRuleProto* self)
+{
+    struct GrammarRuleProto* next;
+    while (self)
+    {
+        next = self->next;
+        assert(self->name);
+        free(self->name);
+        grammar_rule_single_free(self->rules);
+        free(self);
+        self = next;
+    }
+}
+
+void file_free(struct File* self)
+{
+    key_val_free(self->header);
+    lexer_rule_free(self->lexer_rules);
+    grammar_rule_multi_free(self->grammar_rules);
+    free(self);
+}

--- a/src/codegen/compiler.c
+++ b/src/codegen/compiler.c
@@ -13,8 +13,9 @@ kv* declare_start(const TokenPosition* p, char* union_type, char* rule)
     return key_val_build(p, KEY_VAL_START, union_type, rule);
 }
 
+static
 kv* tokens_to_kv(
-        const struct Token* tokens,
+        struct Token* tokens,
         const char* key,
         key_val_t type,
         key_val_t ascii_type,
@@ -22,7 +23,7 @@ kv* tokens_to_kv(
 {
     kv* next = NULL;
     kv* first = NULL;
-    for (const struct Token* iter = tokens; iter; iter = iter->next)
+    for (struct Token* iter = tokens; iter; iter = iter->next)
     {
         if (iter->ascii && !allow_ascii)
         {
@@ -33,7 +34,8 @@ kv* tokens_to_kv(
         kv* curr = key_val_build(&iter->position,
                                  iter->ascii ? ascii_type : type,
                                  key ? strdup(key) : NULL,
-                                 iter->name ? strdup(iter->name) : NULL);
+                                 iter->name ?  : NULL);
+        iter->name = NULL;
 
         curr->next = next;
         next = curr;
@@ -44,6 +46,7 @@ kv* tokens_to_kv(
         }
     }
 
+    tokens_free(tokens);
     return first;
 }
 

--- a/src/codegen/compiler.c
+++ b/src/codegen/compiler.c
@@ -34,7 +34,7 @@ kv* tokens_to_kv(
         kv* curr = key_val_build(&iter->position,
                                  iter->ascii ? ascii_type : type,
                                  key ? strdup(key) : NULL,
-                                 iter->name ?  : NULL);
+                                 iter->name);
         iter->name = NULL;
 
         curr->next = next;

--- a/src/codegen/compiler.c
+++ b/src/codegen/compiler.c
@@ -47,6 +47,8 @@ kv* tokens_to_kv(
     }
 
     tokens_free(tokens);
+    assert(first->next == NULL);
+    first->back = next;
     return first;
 }
 

--- a/src/codegen/compiler.c
+++ b/src/codegen/compiler.c
@@ -1,0 +1,156 @@
+#include <malloc.h>
+#include <string.h>
+#include <assert.h>
+#include "compiler.h"
+
+kv* declare_option(const TokenPosition* p, char* name, char* value)
+{
+    return key_val_build(p, KEY_VAL_OPTION, name, value);
+}
+
+kv* declare_start(const TokenPosition* p, char* union_type, char* rule)
+{
+    return key_val_build(p, KEY_VAL_START, union_type, rule);
+}
+
+kv* tokens_to_kv(
+        const struct Token* tokens,
+        const char* key,
+        key_val_t type,
+        key_val_t ascii_type,
+        int allow_ascii)
+{
+    kv* next = NULL;
+    kv* first = NULL;
+    for (const struct Token* iter = tokens; iter; iter = iter->next)
+    {
+        if (iter->ascii && !allow_ascii)
+        {
+            emit_error(&iter->position, "ASCII tokens not allowed here");
+            break;
+        }
+
+        kv* curr = key_val_build(&iter->position,
+                                 iter->ascii ? ascii_type : type,
+                                 key ? strdup(key) : NULL,
+                                 iter->name ? strdup(iter->name) : NULL);
+
+        curr->next = next;
+        next = curr;
+
+        if (!first)
+        {
+            first = curr;
+        }
+    }
+
+    return first;
+}
+
+kv* declare_tokens(struct Token* tokens)
+{
+    /* Build a list of key_vals */
+    /* Order is not important so we can build backs */
+    return tokens_to_kv(tokens, NULL, KEY_VAL_TOKEN, KEY_VAL_TOKEN_ASCII, 1);
+}
+
+kv* declare_typed_tokens(char* type, struct Token* tokens)
+{
+    kv* out = tokens_to_kv(tokens, type, KEY_VAL_TOKEN_TYPE, KEY_VAL_TOKEN_TYPE, 0);
+    free(type);
+    return out;
+}
+
+kv* declare_types(char* type, struct Token* tokens)
+{
+    kv* out = tokens_to_kv(tokens, type, KEY_VAL_TYPE, KEY_VAL_TYPE, 0);
+    free(type);
+    return out;
+}
+
+kv* declare_destructor(const TokenPosition* p, char* type, char* action)
+{
+    return key_val_build(p, KEY_VAL_DESTRUCTOR, type, action);
+}
+
+kv* declare_right(struct Token* tokens)
+{
+    return tokens_to_kv(tokens, NULL, KEY_VAL_RIGHT, KEY_VAL_RIGHT, 1);
+}
+
+kv* declare_left(struct Token* tokens)
+{
+    return tokens_to_kv(tokens, NULL, KEY_VAL_LEFT, KEY_VAL_LEFT, 1);
+}
+
+kv* declare_top(const TokenPosition* p, char* action)
+{
+    return key_val_build(p, KEY_VAL_TOP, NULL, action);
+}
+
+
+kv* declare_bottom(const TokenPosition* p, char* action)
+{
+    return key_val_build(p, KEY_VAL_BOTTOM, NULL, action);
+}
+kv* declare_union(const TokenPosition* p, char* action)
+{
+    return key_val_build(p, KEY_VAL_UNION, NULL, action);
+}
+
+lr_p* declare_state_rule(const TokenPosition* p, char* state_name, lr_p* rules)
+{
+    lr_p* out = malloc(sizeof(struct LexerRuleProto));
+    assert(p);
+    out->position = *p;
+    out->lexer_state = state_name;
+    out->state_rules = rules;
+    out->regex = NULL;
+    out->function = NULL;
+    out->next = NULL;
+    return out;
+}
+
+lr_p* declare_lexer_rule(const TokenPosition* p, char* regex, char* action)
+{
+    lr_p* out = malloc(sizeof(struct LexerRuleProto));
+    assert(p);
+    out->position = *p;
+    out->lexer_state = NULL;
+    out->state_rules = NULL;
+    out->regex = regex;
+    out->function = action;
+    out->next = NULL;
+    return out;
+}
+
+grs_p* declare_single_grammar(const TokenPosition* p, struct Token* tokens, char* action)
+{
+    grs_p* out = malloc(sizeof(struct GrammarRuleSingleProto));
+    assert(p);
+    out->position = *p;
+    out->next = NULL;
+    out->tokens = tokens;
+    out->function = action;
+    return out;
+}
+
+gr_p* declare_grammar(const TokenPosition* p, char* name, grs_p* grammars)
+{
+    gr_p* out = malloc(sizeof(struct GrammarRuleProto));
+    assert(p);
+    out->position = *p;
+    out->next = NULL;
+    out->name = name;
+    out->rules = grammars;
+    return out;
+}
+
+f_p* declare_file(kv* header, lr_p* lexer_rules, gr_p* grammars)
+{
+    f_p* out = malloc(sizeof(struct File));
+    out->header = header;
+    out->lexer_rules = lexer_rules;
+    out->grammar_rules = grammars;
+    return out;
+}

--- a/src/codegen/compiler.h
+++ b/src/codegen/compiler.h
@@ -1,0 +1,31 @@
+#ifndef NEOAST_COMPILER_H
+#define NEOAST_COMPILER_H
+
+#include "codegen.h"
+
+typedef struct KeyVal kv;
+typedef struct LexerRuleProto lr_p;
+typedef struct GrammarRuleSingleProto grs_p;
+typedef struct GrammarRuleProto gr_p;
+typedef struct File f_p;
+
+kv* declare_option(const TokenPosition* p, char* name, char* value);
+kv* declare_start(const TokenPosition* p, char* union_type, char* rule);
+kv* declare_tokens(struct Token* tokens);
+kv* declare_typed_tokens(char* type, struct Token* tokens);
+kv* declare_types(char* type, struct Token* tokens);
+kv* declare_destructor(const TokenPosition* p, char* type, char* action);
+kv* declare_right(struct Token* tokens);
+kv* declare_left(struct Token* tokens);
+kv* declare_bottom(const TokenPosition* p, char* action);
+kv* declare_top(const TokenPosition* p, char* action);
+kv* declare_union(const TokenPosition* p, char* action);
+
+lr_p* declare_lexer_rule(const TokenPosition* p, char* regex, char* action);
+lr_p* declare_state_rule(const TokenPosition* p, char* state_name, lr_p* rules);
+grs_p* declare_single_grammar(const TokenPosition* p, struct Token* tokens, char* action);
+
+gr_p* declare_grammar(const TokenPosition* p, char* name, grs_p* grammars);
+f_p* declare_file(kv* header, lr_p* lexer_rules, gr_p* grammars);
+
+#endif //NEOAST_COMPILER_H

--- a/src/codegen/compiler_compiler.y
+++ b/src/codegen/compiler_compiler.y
@@ -1,0 +1,308 @@
+%top {
+
+#include <stdlib.h>
+#include <codegen/codegen.h>
+#include <codegen/compiler.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdint.h>
+#include <assert.h>
+
+struct LexerTextBuffer
+{
+    int32_t counter;
+    uint32_t s;
+    uint32_t n;
+    char* buffer;
+};
+
+static __thread struct LexerTextBuffer brace_buffer = {0};
+
+static inline void ll_add_to_brace(const char* lex_text, uint32_t len);
+static inline void ll_match_brace(ParsingStack* lex_state);
+
+}
+
+%bottom {
+
+static inline void ll_add_to_brace(const char* lex_text, uint32_t len)
+{
+    if (len + brace_buffer.n >= brace_buffer.s)
+    {
+        brace_buffer.s *= 2;
+        brace_buffer.buffer = realloc(brace_buffer.buffer, brace_buffer.s);
+    }
+
+    strncpy(brace_buffer.buffer + brace_buffer.n, lex_text, len);
+    brace_buffer.n += len;
+}
+
+static inline void ll_match_brace(ParsingStack* lex_state)
+{
+    NEOAST_STACK_PUSH(lex_state, S_MATCH_BRACE);
+    brace_buffer.s = 1024;
+    brace_buffer.buffer = malloc(brace_buffer.s);
+    brace_buffer.n = 0;
+    brace_buffer.counter = 1;
+}
+
+}
+
+%option parser_type="LALR(1)"
+%option prefix="cc"
+%option track_position="TRUE"
+%option debug_table="TRUE"
+
+%union {
+    char* identifier;
+    char ascii;
+    key_val_t key_val_type;
+    struct KeyVal* key_val;
+    struct LexerRuleProto* l_rule;
+    struct Token* token;
+    struct GrammarRuleSingleProto* g_single_rule;
+    struct GrammarRuleProto* g_rule;
+    struct File* file;
+}
+
+%token LL
+%token GG
+%token OPTION
+%token START
+%token UNION
+%token TYPE
+%token LEFT
+%token RIGHT
+%token TOP
+%token END_STATE
+%token<key_val> MACRO
+%token BOTTOM
+%token TOKEN // %token
+%token DESTRUCTOR
+%token '<'
+%token '>'
+%token ':'
+%token '|'
+%token ';'
+%token '='
+%token<ascii> ASCII
+%token<identifier> LITERAL
+%token<identifier> ACTION
+%token<identifier> IDENTIFIER
+%token<identifier> LEX_STATE
+%type<g_single_rule> single_grammar
+%type<g_single_rule> multi_grammar
+%type<g_rule> grammar
+%type<g_rule> grammars
+
+%type<key_val> header
+%type<key_val_type> unary
+%type<key_val> pair
+%type<l_rule> lexer_rules
+%type<l_rule> lexer_rule
+%type<token> tokens
+%type<token> token
+
+%type <file> program
+%start <file> program
+
+%destructor<identifier> { free($$); }
+
++literal        \"(\\.|[^\"\\])*\"
++identifier     [A-Za-z_][\w]*
++lex_state      <[A-Za-z_][\w]>[\s]*'{'
++ascii          '[\x20-\x7E]'
+
+==
+
+// Initial state
+
+// Whitespace
+"[\n]"              { position->line++; }
+"[ \t\r]+"          { /* skip */ }
+"//[^\n]*"          { /* skip */ }
+"/\*"               { NEOAST_STACK_PUSH(lex_state, S_COMMENT); }
+
+// These take precedence over literal tokens
+"{literal}"         { yyval->identifier = strndup(yytext + 1, len - 2); return LITERAL; }
+"{ascii}"           { yyval->ascii = yytext[1]; return ASCII; }
+
+// Don't build anything during lexing to keep things simple
+// This is different from the way the bootstraping compiler does it
+"=="                { NEOAST_STACK_PUSH(lex_state, S_LL_RULES); return LL; }
+"%%"                { NEOAST_STACK_PUSH(lex_state, S_GG_RULES); return GG; }
+"="                 { return '='; }
+"<"                 { return '<'; }
+">"                 { return '>'; }
+"%option"           { return OPTION; }
+"%token"            { return TOKEN; }
+"%start"            { return START; }
+"%union"            { return UNION; }
+"%type"             { return TYPE; }
+"%left"             { return LEFT; }
+"%right"            { return RIGHT; }
+"%top"              { return TOP; }
+"%bottom"           { return BOTTOM; }
+"%destructor"       { return DESTRUCTOR; }
+"\+{identifier}[ ][\s]*[^\n]+"
+                    {
+                        // Find the white space delimiter
+                        const char* split = strchr(yytext + 1, ' ');
+                        assert(split);
+
+                        char* key = strndup(yytext + 1, split - yytext - 1);
+
+                        // Find the start of the regex rule
+                        while (*split == ' ') split++;
+
+                        char* value = strdup(split);
+                        yyval->key_val = key_val_build(position, KEY_VAL_MACRO, key, value);
+                        return MACRO;
+                    }
+"{identifier}"      { yyval->identifier = strdup(yytext); return IDENTIFIER; }
+"{"                 { ll_match_brace(lex_state); }
+
+<S_LL_RULES> {
+"[\n]"              { position->line++; }
+"[ \t\r\\]+"        { /* skip */ }
+"//[^\n]*"          { /* skip */ }
+"/\*"               { NEOAST_STACK_PUSH(lex_state, S_COMMENT); }
+"=="                { NEOAST_STACK_POP(lex_state); return LL; }
+"{lex_state}"       {
+                        const char* start_ptr = strchr(yytext, '<');
+                        const char* end_ptr = strchr(yytext, '>');
+                        yyval->identifier = strndup(start_ptr + 1, end_ptr - start_ptr - 1);
+                        NEOAST_STACK_PUSH(lex_state, S_LL_STATE);
+
+                        return LEX_STATE;
+                    }
+"{literal}"         { yyval->identifier = strndup(yytext + 1, len - 2); return LITERAL; }
+"{"                 { ll_match_brace(lex_state); }
+}
+
+<S_LL_STATE> {
+"[\n]"              { position->line++; }
+"[ \t\r\\]+"        { /* skip */ }
+"//[^\n]*"          { /* skip */ }
+"/\*"               { NEOAST_STACK_PUSH(lex_state, S_COMMENT); }
+
+"{literal}"         { yyval->identifier = strndup(yytext + 1, len - 2); return LITERAL; }
+
+"{"                 { ll_match_brace(lex_state); }
+"}"                 { NEOAST_STACK_POP(lex_state); return END_STATE; }
+
+}
+
+<S_GG_RULES> {
+"[\n]"              { position->line++; }
+"[ \t\r]+"          { /* skip */ }
+"//[^\n]*"          { /* skip */ }
+"{ascii}"           { yyval->ascii = yytext[1]; return ASCII; }
+"/\*"               { NEOAST_STACK_PUSH(lex_state, S_COMMENT); }
+"%%"                { NEOAST_STACK_POP(lex_state); return GG; }
+"{identifier}"      { yyval->identifier = strdup(yytext); return IDENTIFIER; }
+":"                 { return ':'; }
+"\|"                { return '|'; }
+";"                 { return ';'; }
+"{"                 { ll_match_brace(lex_state); }
+}
+
+<S_MATCH_BRACE> {
+"[\n]"              { position->line++; ll_add_to_brace(yytext, len); }
+
+// Add ascii charaters
+"'[\x00-\x7F]'"     { ll_add_to_brace(yytext, len); }
+
+// String literals
+"\"(\\.|[^\"\\])*\"" { ll_add_to_brace(yytext, len); }
+
+// Everything else
+"([^}{\"\'\n]+)"      { ll_add_to_brace(yytext, len); }
+
+"{"                 { brace_buffer.counter++; brace_buffer.buffer[brace_buffer.n++] = '{'; }
+"}"                 {
+                        brace_buffer.counter--;
+                        if (brace_buffer.counter <= 0)
+                        {
+                            // This is the outer-most brace
+                            brace_buffer.buffer[brace_buffer.n++] = 0;
+                            NEOAST_STACK_POP(lex_state);
+                            yyval->identifier = strndup(brace_buffer.buffer, brace_buffer.n);
+                            free(brace_buffer.buffer);
+                            brace_buffer.buffer = NULL;
+                            return ACTION;
+                        }
+                        else
+                        {
+                            brace_buffer.buffer[brace_buffer.n++] = '}';
+                        }
+                    }
+}
+
+<S_COMMENT> {
+"[\n]"              { position->line++; }
+"[^\*\n]+"          { /* Absorb comment */ }
+"\*/"               { NEOAST_STACK_POP(lex_state); }
+"\*"                { }
+}
+
+==
+
+%%
+
+token: IDENTIFIER                   { $$ = build_token($p1, $1); }
+     | ASCII                        { $$ = build_token_ascii($p1, $1); }
+     ;
+
+tokens: token                       { $$ = $1; }
+      | token tokens                { $$ = $1; $$->next = $2; }
+      ;
+
+pair: OPTION IDENTIFIER '=' LITERAL         { $$ = declare_option($p1, $2, $4); }
+    | TOKEN tokens                          { $$ = declare_tokens($2); }
+    | START '<' IDENTIFIER '>' IDENTIFIER   { $$ = declare_start($p1, $3, $5); }
+    | TOKEN '<' IDENTIFIER '>' tokens       { $$ = declare_typed_tokens($3, $5); }
+    | TYPE '<' IDENTIFIER '>' tokens        { $$ = declare_types($3, $5); }
+    | DESTRUCTOR '<' IDENTIFIER '>' ACTION  { $$ = declare_destructor($p1, $3, $5); }
+    | RIGHT tokens                          { $$ = declare_right($2); }
+    | LEFT tokens                           { $$ = declare_left($2); }
+    | TOP ACTION                            { $$ = declare_top($p1, $2); }
+    | BOTTOM ACTION                         { $$ = declare_bottom($p1, $2); }
+    | UNION ACTION                          { $$ = declare_union($p1, $2); }
+    | MACRO                                 { $$ = $1; }
+    ;
+
+header: pair                        { $$ = $1; }
+      | pair header                 { $$ = $1; $$->next = $2; }
+      ;
+
+lexer_rule: LITERAL ACTION          { $$ = declare_lexer_rule($p1, $1, $2); }
+          ;
+
+lexer_rules: lexer_rule             { $$ = $1; }
+           | lexer_rule lexer_rules { $$ = $1; $$->next = $2; }
+           | LEX_STATE lexer_rules END_STATE { $$ = declare_state_rule($p1, $1, $2); }
+           ;
+
+single_grammar: tokens ACTION                   { $$ = declare_single_grammar($p2, $1, $2); }
+              ;
+
+multi_grammar: single_grammar                   { $$ = $1; }
+             | single_grammar '|' multi_grammar { $$ = $1; $$->next = $3; }
+
+             // Empty rule
+             | ACTION                           { $$ = declare_single_grammar($p1, NULL, $1); }
+             ;
+
+grammar: IDENTIFIER ':' multi_grammar ';'       { $$ = declare_grammar($p1, $1, $3); }
+       ;
+
+
+grammars: grammar                   { $$ = $1; }
+        | grammar grammars          { $$ = $1; $$->next = $2; }
+        ;
+
+program: header LL lexer_rules LL GG grammars GG { $$ = declare_file($1, $3, $6); }
+       ;
+
+%%

--- a/src/codegen/compiler_compiler.y
+++ b/src/codegen/compiler_compiler.y
@@ -117,6 +117,8 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 +identifier     [A-Za-z_][\w]*
 +lex_state      <[A-Za-z_][\w]>[\s]*'{'
 +ascii          '[\x20-\x7E]'
++macro          \+{identifier}[ ][\s]*[^\n]+
++whitespace     [ \t\r]+
 
 ==
 
@@ -124,7 +126,7 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 
 // Whitespace
 "[\n]"              { position->line++; }
-"[ \t\r]+"          { /* skip */ }
+"{whitespace}"      { /* skip */ }
 "//[^\n]*"          { /* skip */ }
 "/\*"               { NEOAST_STACK_PUSH(lex_state, S_COMMENT); }
 
@@ -149,8 +151,7 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 "%top"              { return TOP; }
 "%bottom"           { return BOTTOM; }
 "%destructor"       { return DESTRUCTOR; }
-"\+{identifier}[ ][\s]*[^\n]+"
-                    {
+"{macro}"           {
                         // Find the white space delimiter
                         const char* split = strchr(yytext + 1, ' ');
                         assert(split);
@@ -169,7 +170,7 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 
 <S_LL_RULES> {
 "[\n]"              { position->line++; }
-"[ \t\r\\]+"        { /* skip */ }
+"{whitespace}"      { /* skip */ }
 "//[^\n]*"          { /* skip */ }
 "/\*"               { NEOAST_STACK_PUSH(lex_state, S_COMMENT); }
 "=="                { NEOAST_STACK_POP(lex_state); return LL; }
@@ -187,7 +188,7 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 
 <S_LL_STATE> {
 "[\n]"              { position->line++; }
-"[ \t\r\\]+"        { /* skip */ }
+"{whitespace}"      { /* skip */ }
 "//[^\n]*"          { /* skip */ }
 "/\*"               { NEOAST_STACK_PUSH(lex_state, S_COMMENT); }
 
@@ -200,7 +201,7 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 
 <S_GG_RULES> {
 "[\n]"              { position->line++; }
-"[ \t\r]+"          { /* skip */ }
+"{whitespace}"      { /* skip */ }
 "//[^\n]*"          { /* skip */ }
 "{ascii}"           { yyval->ascii = yytext[1]; return ASCII; }
 "/\*"               { NEOAST_STACK_PUSH(lex_state, S_COMMENT); }

--- a/src/codegen/compiler_compiler.y
+++ b/src/codegen/compiler_compiler.y
@@ -79,24 +79,23 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 %token BOTTOM
 %token TOKEN // %token
 %token DESTRUCTOR
+%token<ascii> ASCII
+%token<identifier> LITERAL
+%token<identifier> ACTION
+%token<identifier> IDENTIFIER
+%token<identifier> LEX_STATE
 %token '<'
 %token '>'
 %token ':'
 %token '|'
 %token ';'
 %token '='
-%token<ascii> ASCII
-%token<identifier> LITERAL
-%token<identifier> ACTION
-%token<identifier> IDENTIFIER
-%token<identifier> LEX_STATE
 %type<g_single_rule> single_grammar
 %type<g_single_rule> multi_grammar
 %type<g_rule> grammar
 %type<g_rule> grammars
 
 %type<key_val> header
-%type<key_val_type> unary
 %type<key_val> pair
 %type<l_rule> lexer_rules
 %type<l_rule> lexer_rule
@@ -107,6 +106,12 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 %start <file> program
 
 %destructor<identifier> { free($$); }
+%destructor<l_rule> { lexer_rule_free($$); }
+%destructor<g_single_rule> { grammar_rule_single_free($$); }
+%destructor<g_rule> { grammar_rule_multi_free($$); }
+%destructor<key_val> { key_val_free($$); }
+%destructor<token> { tokens_free($$); }
+%destructor<file> { file_free($$); }
 
 +literal        \"(\\.|[^\"\\])*\"
 +identifier     [A-Za-z_][\w]*

--- a/src/codegen/compiler_compiler.y
+++ b/src/codegen/compiler_compiler.y
@@ -279,7 +279,7 @@ pair: OPTION IDENTIFIER '=' LITERAL         { $$ = declare_option($p1, $2, $4); 
     ;
 
 header: pair                        { $$ = $1; }
-      | pair header                 { $$ = $1; $$->next = $2; }
+      | pair header                 { $$ = $1->back ? $1->back : $1; $1->next = $2; }
       ;
 
 lexer_rule: LITERAL ACTION          { $$ = declare_lexer_rule($p1, $1, $2); }

--- a/src/codegen/compiler_compiler.y
+++ b/src/codegen/compiler_compiler.y
@@ -51,7 +51,7 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 %option parser_type="LALR(1)"
 %option prefix="cc"
 %option track_position="TRUE"
-%option debug_table="TRUE"
+%option debug_table="FALSE"
 
 %union {
     char* identifier;

--- a/src/codegen/main.c
+++ b/src/codegen/main.c
@@ -20,8 +20,125 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
-#include "lexer.h"
-#include "codegen.h"
+#include <assert.h>
+#include <stdarg.h>
+#include "codegen/codegen.h"
+
+#define ERROR_CONTEXT_LINE_N 3
+
+uint32_t cc_init();
+void cc_free();
+void* cc_allocate_buffers();
+void cc_free_buffers(void* self);
+struct File* cc_parse_len(void* buffers, const char* input, uint64_t input_len);
+
+
+const char* path = NULL;
+const char** file_lines = NULL;
+static int error_counter = 0;
+
+static void put_position(const TokenPosition* self, const char* type)
+{
+    assert(file_lines);
+    assert(type);
+    assert(self);
+    assert(path);
+
+    for (int i = (int)self->line - ERROR_CONTEXT_LINE_N; i < self->line; i++)
+    {
+        if (i < 0)
+        {
+            continue;
+        }
+
+        char* newline_pos = strchr(file_lines[i], '\n');
+        if (newline_pos)
+        {
+            fprintf(stderr, "%03d |%.*s\n", i + 1, (int)(newline_pos - file_lines[i]), file_lines[i]);
+        }
+        else
+        {
+            fprintf(stderr, "%03d |%s\n", i + 1, file_lines[i]);
+        }
+    }
+
+    if (self->line > 0)
+    {
+        for (int j = 0; j < self->col_start + 4; j++)
+        {
+            fputc(' ', stderr);
+        }
+
+        fprintf(stderr, "^\n%s at %s:%d: ", type, path, self->line);
+    }
+    else
+    {
+        fprintf(stderr, "%s: ", type);
+    }
+}
+
+static char* read_file(FILE* fp, size_t* file_size)
+{
+    fseek(fp, 0L, SEEK_END);
+    *file_size = ftell(fp);
+    fseek(fp, 0L, SEEK_SET);
+
+    // Read the whole file
+    char* input = malloc(*file_size + 1);
+    size_t offset = 0;
+    while ((offset += fread(input + offset, 1, 1024, fp)) < *file_size);
+    input[*file_size] = 0;
+
+    /* Fill the file lines */
+    size_t line_n = 0;
+    size_t line_s = *file_size >> 6;
+    file_lines = malloc(sizeof(char*) * line_s);
+
+    char* end = input;
+    while(end)
+    {
+        if (line_n + 1 >= line_s)
+        {
+            line_s *= 2;
+            file_lines = realloc(file_lines, sizeof(char*) * line_s);
+        }
+
+        file_lines[line_n++] = end;
+        end = strchr(end, '\n');
+        if (end)
+        {
+            end++;
+        }
+    }
+
+    return input;
+}
+
+void emit_warning(const TokenPosition* p, const char* format, ...)
+{
+    put_position(p, "Warning");
+    va_list args;
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
+    fputc('\n', stderr);
+}
+
+int has_errors()
+{
+    return error_counter;
+}
+
+void emit_error(const TokenPosition* p, const char* format, ...)
+{
+    put_position(p, "Error");
+    va_list args;
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
+    fputc('\n', stderr);
+    error_counter++;
+}
 
 int main(int argc, const char* argv[])
 {
@@ -33,61 +150,44 @@ int main(int argc, const char* argv[])
 
     char* input;
     FILE* fp = fopen(argv[1], "r");
+    path = argv[1];
     if (!fp)
     {
         fprintf(stderr, "Failed to open '%s': %s\n", argv[1], strerror(errno));
         return 1;
     }
 
-    fseek(fp, 0L, SEEK_END);
-    size_t file_size = ftell(fp);
-    fseek(fp, 0L, SEEK_SET);
-
-    // Read the whole file
-    input = malloc(file_size + 1);
-    size_t offset = 0;
-    while ((offset += fread(input + offset, 1, 1024, fp)) < file_size);
-    input[file_size] = 0;
+    size_t file_size;
+    input = read_file(fp, &file_size);
     fclose(fp);
 
-    GrammarParser parser;
-    if (gen_parser_init(&parser))
-    {
-        free(input);
-        return 1;
-    }
+    cc_init();
+    void* buf = cc_allocate_buffers();
+    struct File* f = cc_parse_len(buf, input, file_size);
 
-    ParserBuffers* buf = parser_allocate_buffers(1024, 1024, 16, 1024, sizeof(CodegenUnion));
+    free(input);
+    cc_free();
+    cc_free_buffers(buf);
 
-    int32_t result_idx = parser_parse_lr(&parser, GEN_parsing_table, buf, input, file_size);
-
-    if (result_idx == -1)
+    if (!f)
     {
         fprintf(stderr, "Failed to parse file '%s'\n", argv[1]);
-        parser_free_buffers(buf);
-        parser_free(&parser);
-        free(input);
         return 1;
     }
 
-    struct File* f = ((CodegenUnion*)buf->value_table)[result_idx].file;
     fp = fopen(argv[2], "w+");
     if (!fp)
     {
         fprintf(stderr, "Failed to open '%s': %s\n", argv[1], strerror(errno));
-        parser_free_buffers(buf);
-        parser_free(&parser);
-        free(input);
         file_free(f);
+        free(file_lines);
         return 1;
     }
 
     int error = codegen_write(f, fp);
     fclose(fp);
+    free(file_lines);
 
-    parser_free_buffers(buf);
-    parser_free(&parser);
-    free(input);
     file_free(f);
     return error;
 }

--- a/src/codegen/regex.c
+++ b/src/codegen/regex.c
@@ -129,6 +129,8 @@ char* regex_expand(MacroEngine* self, const char* regex)
         return expanded_pattern;
     }
 
+    assert(regex);
+
     // We didn't expand anything, simply dup the input
     return strdup(regex);
 }

--- a/test/input/calculator.y
+++ b/test/input/calculator.y
@@ -13,24 +13,15 @@
 %option prefix="calc"
 
 %token<number> TOK_N
-%token TOK_PLUS
-%token TOK_MINUS
-%token TOK_SLASH
-%token TOK_STAR
-%token TOK_CARET
-%token TOK_P_OPEN
-%token TOK_P_CLOSE
+%token TOK_PLUS TOK_MINUS TOK_SLASH TOK_STAR
+       TOK_CARET TOK_P_OPEN TOK_P_CLOSE
 
-%type <number> expr
-%type <number> program
+%type <number> expr program
 %start <number> program
 
 // Test global comment
 
-%left TOK_PLUS
-%left TOK_MINUS
-%left TOK_STAR
-%left TOK_SLASH
+%left TOK_PLUS TOK_MINUS TOK_STAR TOK_SLASH
 %right TOK_CARET
 
 %union {

--- a/test/input/calculator.y
+++ b/test/input/calculator.y
@@ -43,8 +43,8 @@
 
 ==
 // Test lex rule comment
-"[ ]+"         {return -1;}
-"[0-9]+"       {yyval->number = strtod(yytext, NULL); return TOK_N;}
+"[ ]+"        {return -1;}
+"[0-9]+"      {yyval->number = strtod(yytext, NULL); return TOK_N;}
 "\+"          {return TOK_PLUS;}
 "\-"          {return TOK_MINUS;}
 "\/"          {return TOK_SLASH;}

--- a/test/input/calculator_ascii.y
+++ b/test/input/calculator_ascii.y
@@ -13,6 +13,10 @@
 %option debug_ids="$d+-/*^()ES"
 %option prefix="calc_ascii"
 
+%union {
+    double number;
+}
+
 %token<number> TOK_N
 %token '+'
 %token '-'
@@ -35,14 +39,10 @@
 %left '/'
 %right '^'
 
-%union {
-    double number;
-}
-
 ==
 // Test lex rule comment
-"[ ]+"         {return -1;}
-"[0-9]+"       {yyval->number = strtod(yytext, NULL); return TOK_N;}
+"[ ]+"        {return -1;}
+"[0-9]+"      {yyval->number = strtod(yytext, NULL); return TOK_N;}
 "\+"          {return '+';}
 "\-"          {return '-';}
 "\/"          {return '/';}

--- a/test/input/simple_ast.y
+++ b/test/input/simple_ast.y
@@ -40,6 +40,7 @@ void required_use_stmt_free(RequiredUse* self)
 //%option disable_locks="TRUE"
 %option debug_table="TRUE"
 %option prefix="required_use"
+%option debug_ids="$ids!?()ESDRP"
 
 %union {
     char* identifier;
@@ -60,19 +61,17 @@ void required_use_stmt_free(RequiredUse* self)
 %type <use_select> depend_expr_sel
 %type <use_select> use_expr
 
-%start<required_use> program_required_use
-%type <required_use> program_required_use
+%destructor <identifier> { free($$); }
+%destructor <use_select> { if($$.target) free($$.target); }
+%destructor <required_use> { required_use_stmt_free($$); }
 
 %token '!'
 %token '?'
 %token '('
 %token ')'
 
-%option debug_ids="$ids!?()ESDRP"
-
-%destructor <identifier> { free($$); }
-%destructor <use_select> { if($$.target) free($$.target); }
-%destructor <required_use> { required_use_stmt_free($$); }
+%start<required_use> program_required_use
+%type <required_use> program_required_use
 
 
 +identifier      [A-Za-z_0-9][A-Za-z_0-9\-\+]*


### PR DESCRIPTION
Moves the current compiler-compiler (...compiler?) to `codegen/boostrap`. Here an intermediate binary will be built to parse the grammar in `compiler_compiler.y` which describes the input file syntax. This will generate a leak-free parser with context and positional error messaging for input files

The bootstrap compiler-compiler is just meant to be as simple as possible with no nice features like error messaging or position feedback because its just meant to build a single input file.

Closes #52 
Closes #51 