### PR TITLE
Implement user defined error callbacks

### DIFF
--- a/include/neoast.h
+++ b/include/neoast.h
@@ -59,6 +59,24 @@ typedef int32_t (*lexer_expr) (
         TokenPosition* position);
 typedef void (*parser_destructor) (void* self);
 
+
+// User defined error callbacks
+
+// Called when no matching token could be found
+typedef void (*ll_error_cb)(
+        const char* input,              //!< Input passed in with parse()
+        const TokenPosition* position,  //!< Position of unmatched token (or NULL if track_position != TRUE)
+        uint32_t offset);               //!< Offset in bytes where no token match was found
+                                        //!< Offset from start of file
+
+typedef void (*yy_error_cb)(
+        const char* const* token_names,
+        const TokenPosition* position,
+        uint32_t last_token,
+        uint32_t current_token,
+        const uint32_t expected_tokens[],
+        uint32_t expected_tokens_n);
+
 enum
 {
     // Accept an input during an augmented state
@@ -119,6 +137,9 @@ struct GrammarParser_prv
     const GrammarRule* grammar_rules;
     const char* const* token_names;
     parser_destructor const* destructors;
+
+    ll_error_cb lexer_error;
+    yy_error_cb parser_error;
 
     // Also number of columns
     uint32_t token_n;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_mocked_test(tablegen_C
 BuildParser(calculator_parser input/calculator.y)
 BuildParser(calculator_ascii_parser input/calculator_ascii.y)
 BuildParser(simple_ast_parser input/simple_ast.y)
+BuildParser(error_parser input/error_cb.y)
 add_mocked_test(integration_C
         SOURCES
         input/calculator.y
@@ -35,6 +36,7 @@ add_mocked_test(integration_C
         ${calculator_parser_OUTPUT}
         ${calculator_ascii_parser_OUTPUT}
         ${simple_ast_parser_OUTPUT}
+        ${error_parser_OUTPUT}
         LINK_LIBRARIES neoast m
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         ENVIRONMENT ${EXEC_ENV}

--- a/test/input/error_cb.y
+++ b/test/input/error_cb.y
@@ -1,0 +1,59 @@
+%top {
+#include <stdlib.h>
+#include <stddef.h>
+
+void lexer_error_cb(const char* input,
+                    const TokenPosition* position,
+                    uint32_t offset);
+
+void parser_error_cb(const char* const* token_names,
+                     const TokenPosition* position,
+                     uint32_t last_token,
+                     uint32_t current_token,
+                     const uint32_t expected_tokens[],
+                     uint32_t expected_tokens_n);
+
+}
+
+%option prefix="error"
+%option track_position="TRUE"
+%option parsing_error_cb="parser_error_cb"
+%option lexing_error_cb="lexer_error_cb"
+
+%union {
+    int out;
+}
+%left '+'
+%left '-'
+%right '*'
+%right '/'
+
+%token<out> A_TOKEN
+%token '+' '-' '*' '/'
+%type<out> out
+%type<out> expr
+%start<out> out
+
+==
+"\n"        { position->line++; }
+"[ ]+"      { }
+"[0-9]+"    { yyval->out = strtol(yytext, NULL, 10); return A_TOKEN; }
+"\+"        { return '+'; }
+"-"         { return '-'; }
+"\*"        { return '*'; }
+"/"         { return '/'; }
+==
+
+%%
+
+out: expr           { $$ = $1; }
+    ;
+
+expr: A_TOKEN       { $$ = $1; }
+    | out '+' out   { $$ = $1 + $3; }
+    | out '-' out   { $$ = $1 - $3; }
+    | out '*' out   { $$ = $1 * $3; }
+    | out '/' out   { $$ = $1 / $3; }
+    ;
+
+%%

--- a/test/macro_test.c
+++ b/test/macro_test.c
@@ -16,11 +16,11 @@
  */
 
 
-#include <stdio.h>
-#include <cmocka.h>
 #include <string.h>
 #include <codegen/regex.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <cmocka.h>
 
 #define CTEST(name) static void name(void** state)
 


### PR DESCRIPTION
Pass the user relevant information so that they may use it in a parser or lexer error callback 

Closes #17 