### PR TITLE
Add context errors to compiler-compiler

### DIFF
--- a/src/codegen/compiler_compiler.y
+++ b/src/codegen/compiler_compiler.y
@@ -8,6 +8,17 @@
 #include <stdint.h>
 #include <assert.h>
 
+void lexing_error_cb(const char* input,
+                     const TokenPosition* position,
+                     uint32_t offset);
+
+void parsing_error_cb(const char* const* token_names,
+                      const TokenPosition* position,
+                      uint32_t last_token,
+                      uint32_t current_token,
+                      const uint32_t expected_tokens[],
+                      uint32_t expected_tokens_n);
+
 struct LexerTextBuffer
 {
     int32_t counter;
@@ -52,6 +63,8 @@ static inline void ll_match_brace(ParsingStack* lex_state)
 %option prefix="cc"
 %option track_position="TRUE"
 %option debug_table="FALSE"
+%option lexing_error_cb="lexing_error_cb"
+%option parsing_error_cb="parsing_error_cb"
 
 %union {
     char* identifier;

--- a/src/codegen/main.c
+++ b/src/codegen/main.c
@@ -139,6 +139,42 @@ void emit_error(const TokenPosition* p, const char* format, ...)
     error_counter++;
 }
 
+void lexing_error_cb(const char* input,
+                     const TokenPosition* position,
+                     uint32_t offset)
+{
+    (void) input;
+    (void) offset;
+
+    emit_error(position, "Unmatched token near:");
+}
+
+void parsing_error_cb(const char* const* token_names,
+                      const TokenPosition* position,
+                      uint32_t last_token,
+                      uint32_t current_token,
+                      const uint32_t expected_tokens[],
+                      uint32_t expected_tokens_n)
+{
+    (void) last_token;
+
+    static char error_string[1024];
+    error_string[0] = 0;
+
+    strcat(error_string, "Unexpected token %s, Expected one of: ");
+    for (int i = 0; i < expected_tokens_n; i++)
+    {
+        if (i > 0)
+        {
+            strcat(error_string, ", ");
+        }
+
+        strcat(error_string, token_names[expected_tokens[i]]);
+    }
+
+    emit_error(position, error_string, token_names[current_token]);
+}
+
 int main(int argc, const char* argv[])
 {
     if (argc != 3)


### PR DESCRIPTION
Output nice errors when the grammar is incorrect in the neoast input file.

Example:
```
056 |     | out '/' out   { $$ = $1 / $3; }
057 |     |
058 |     ;
          ^
Error at input/error_cb.y:58: Unexpected token ;, Expected one of: ASCII, ACTION, IDENTIFIER, single_grammar, multi_grammar, tokens, token
```

Related to #56 