### PR TITLE
Place line directives for accurate compiler errors

### DIFF
--- a/src/codegen/bootstrap/main.c
+++ b/src/codegen/bootstrap/main.c
@@ -86,7 +86,7 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    int error = codegen_write(f, fp);
+    int error = codegen_write("bootstrap_grammar", f, fp);
     fclose(fp);
 
     parser_free_buffers(buf);

--- a/src/codegen/bootstrap/main.c
+++ b/src/codegen/bootstrap/main.c
@@ -86,7 +86,7 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    int error = codegen_write("bootstrap_grammar", f, fp);
+    int error = codegen_write(NULL, f, fp);
     fclose(fp);
 
     parser_free_buffers(buf);

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -77,7 +77,12 @@ void put_enum(int start, int n, const char* const* names, FILE* fp)
 }
 
 static inline
-void put_lexer_rule_action(struct LexerRuleProto* self, const char* state_name, uint32_t regex_i, FILE* fp)
+void put_lexer_rule_action(
+        const char* grammar_file_path,
+        struct LexerRuleProto* self,
+        const char* state_name,
+        uint32_t regex_i,
+        FILE* fp)
 {
     fprintf(fp, "static int32_t\nll_rule_%s_%02d(const char* yytext, "
                 CODEGEN_UNION"* yyval, "
@@ -91,6 +96,14 @@ void put_lexer_rule_action(struct LexerRuleProto* self, const char* state_name, 
                 "    (void) lex_state;\n"
                 "    (void) position;\n"
                 "    {", state_name, regex_i);
+
+    // Put a line directive to tell the compiler
+    // where to original code resides
+    if (self->position.line)
+    {
+        fprintf(fp, "\n#line %d \"%s\"\n", self->position.line, grammar_file_path);
+    }
+
     fputs(self->function, fp);
     fputs("}\n    return -1;\n}\n\n", fp);
 }
@@ -251,6 +264,7 @@ const char* put_grammar_rule_arg(
 
 static inline
 void put_grammar_rule_action(
+        const char* grammar_file_path,
         struct GrammarRuleProto* parent,
         struct GrammarRuleSingleProto* self,
         const char** tokens,
@@ -267,13 +281,41 @@ void put_grammar_rule_action(
                 "    (void) args;\n"
                 "    {", rule_n);
 
+    int stop = 0;
+
+    // Put a line directive to tell the compiler
+    // where to original code resides
+    if (self->position.line)
+    {
+        // Return value
+        int expression_token = get_named_token(parent->name, tokens, token_n);
+        if (expression_token == -1)
+        {
+            emit_error(&self->position, "Rule not defined", parent->name);
+            stop = 1;
+        }
+
+        assert(typed_tokens[expression_token]);
+
+        fprintf(fp, "\n#line %d \"%s\"\n", self->position.line, grammar_file_path);
+
+        if (!stop)
+        {
+            for (int i = 0; i < self->position.col_start -
+                                strlen(typed_tokens[expression_token]->key) - 4; i++)
+            {
+                fputc(' ', fp);
+            }
+        }
+    }
+
     // Find all usages of $N or $$
     // Check if this usage should be ignored (comment or string)
     // Replace this usage with the appropriate C-value
 
     const char* search = NULL;
     const char* start = self->function;
-    while ((search = strchr(start, '$')))
+    while ((search = strchr(start, '$')) && !stop)
     {
         if ((search[1] >= '0' && search[1] <= '9') || search[1] == '$' || search[1] == 'p')
         {
@@ -303,12 +345,13 @@ void put_grammar_rule_action(
         fwrite(start, 1, search - start, fp);
         start = search;
     }
+
     if (start)
     {
         fputs(start, fp);
     }
 
-    fputs("}\n}\n\n", fp);
+    fputs("\n    }\n}\n\n", fp);
 }
 
 static inline
@@ -644,7 +687,10 @@ static void codegen_handle_option(
     }
 }
 
-int codegen_write(const struct File* self, FILE* fp)
+int codegen_write(
+        const char* grammar_file_path,
+        const struct File* self,
+        FILE* fp)
 {
     // Codegen steps:
     //   1. Write the header
@@ -1015,7 +1061,7 @@ int codegen_write(const struct File* self, FILE* fp)
                 assert(iter_s->function);
                 assert(!iter_s->lexer_state);
                 assert(!iter_s->state_rules);
-                put_lexer_rule_action(iter_s, lexer_states[state_id], state_iterator, fp);
+                put_lexer_rule_action(grammar_file_path, iter_s, lexer_states[state_id], state_iterator, fp);
                 LexerRule* ll_rule = &ll_rules[state_id][state_iterator++];
                 ll_rule->expr = (lexer_expr) iter_s;
                 char* expanded_regex = regex_expand(m_engine, iter_s->regex);
@@ -1039,7 +1085,7 @@ int codegen_write(const struct File* self, FILE* fp)
             assert(iter->function);
             assert(!iter->lexer_state);
             assert(!iter->state_rules);
-            put_lexer_rule_action(iter, lexer_states[0], iterator, fp);
+            put_lexer_rule_action(grammar_file_path, iter, lexer_states[0], iterator, fp);
             LexerRule* ll_rule = &ll_rules[0][iterator++];
             ll_rule->expr = (lexer_expr) iter;
             char* expanded_regex = regex_expand(m_engine, iter->regex);
@@ -1094,7 +1140,8 @@ int codegen_write(const struct File* self, FILE* fp)
              rule_single_iter;
              rule_single_iter = rule_single_iter->next)
         {
-            put_grammar_rule_action(rule_iter, rule_single_iter, tokens, typed_tokens,
+            put_grammar_rule_action(grammar_file_path,
+                                    rule_iter, rule_single_iter, tokens, typed_tokens,
                                     &options,
                                     token_n, grammar_n + 1, fp);
             grammar_n++;

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -301,8 +301,9 @@ void put_grammar_rule_action(
 
         if (!stop)
         {
-            for (int i = 0; i < self->position.col_start -
-                                strlen(typed_tokens[expression_token]->key) - 4; i++)
+            int space_count = self->position.col_start -
+                              strlen(typed_tokens[expression_token]->key) - 4;
+            for (int i = 0; i < space_count; i++)
             {
                 fputc(' ', fp);
             }

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -99,7 +99,7 @@ void put_lexer_rule_action(
 
     // Put a line directive to tell the compiler
     // where to original code resides
-    if (self->position.line)
+    if (self->position.line && grammar_file_path)
     {
         fprintf(fp, "\n#line %d \"%s\"\n", self->position.line, grammar_file_path);
     }
@@ -285,7 +285,7 @@ void put_grammar_rule_action(
 
     // Put a line directive to tell the compiler
     // where to original code resides
-    if (self->position.line)
+    if (self->position.line && grammar_file_path)
     {
         // Return value
         int expression_token = get_named_token(parent->name, tokens, token_n);

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -91,7 +91,7 @@ struct File
 };
 
 int gen_parser_init(GrammarParser* self);
-int codegen_write(const struct File* self, FILE* fp);
+int codegen_write(const char* grammar_file_path, const struct File* self, FILE* fp);
 
 void emit_warning(const TokenPosition* position, const char* message, ...);
 void emit_error(const TokenPosition* position, const char* message, ...);

--- a/src/codegen/common.c
+++ b/src/codegen/common.c
@@ -13,6 +13,11 @@ struct KeyVal* key_val_build(const TokenPosition* p, key_val_t type, char* key, 
     {
         self->position = *p;
     }
+    else
+    {
+        self->position.line = 0;
+        self->position.col_start = 0;
+    }
 
     self->next = NULL;
     self->back = NULL;
@@ -35,6 +40,11 @@ struct Token* build_token(const TokenPosition* position, char* name)
     if (position)
     {
         self->position = *position;
+    }
+    else
+    {
+        self->position.line = 0;
+        self->position.col_start = 0;
     }
 
     self->name = name;
@@ -62,6 +72,11 @@ struct Token* build_token_ascii(const TokenPosition* position, char value)
     if (position)
     {
         self->position = *position;
+    }
+    else
+    {
+        self->position.line = 0;
+        self->position.col_start = 0;
     }
 
     self->name = get_ascii_token_name(value);

--- a/src/codegen/main.c
+++ b/src/codegen/main.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdarg.h>
+#include <linux/limits.h>
 #include "codegen/codegen.h"
 
 #define ERROR_CONTEXT_LINE_N 3
@@ -222,7 +223,10 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    int error = codegen_write(f, fp);
+    static char full_path[PATH_MAX];
+    const char* full_file_path = realpath(argv[1], full_path);
+
+    int error = codegen_write(full_file_path, f, fp);
     fclose(fp);
     free(file_lines);
     free(input);


### PR DESCRIPTION
Adds `#line` before actions to allow compiler errors to show up in the grammar file.