### PR TITLE
Introduce include directive

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(neoast_builtin_lexer
         PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/../include
         ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/reflex/include)
+target_link_libraries(neoast_builtin_lexer PUBLIC reflex)
 
 target_link_libraries(neoast pthread)
 target_compile_options(neoast PRIVATE -fPIC)

--- a/src/codegen/bootstrap/main.c
+++ b/src/codegen/bootstrap/main.c
@@ -22,6 +22,7 @@
 #include <codegen/builtin_lexer/builtin_lexer.h>
 #include <stddef.h>
 #include "codegen/codegen.h"
+#include "codegen/compiler.h"
 #include "grammar.h"
 
 extern uint32_t* GEN_parsing_table;
@@ -81,6 +82,13 @@ int main(int argc, const char* argv[])
     }
 
     struct File* f = ((CodegenUnion*)buf->value_table)[result_idx].file;
+
+    TokenPosition p = {0, 0};
+    KeyVal* builtin_includes = declare_include(&p,
+                                               strdup("#include <codegen/codegen.h>\n"
+                                                      "#include <codegen/compiler.h>"));
+    builtin_includes->next = f->header;
+    f->header = builtin_includes;
 
     int error = codegen_write(NULL, f, argv[2], argv[3]);
 

--- a/src/codegen/cg_util.cc
+++ b/src/codegen/cg_util.cc
@@ -4,15 +4,16 @@
 #include "cg_util.h"
 #include "codegen_priv.h"
 
+reflex::Pattern redzone_pattern(
+        "(?mx)"
+        "(\\/\\/[^\n]*\n)|"                 // Line comments
+        "(\\/\\*(?:\\*(?!\\/)|[^*])*\\*\\/)|" // Block comments
+        "(\"(?:[^\"\\\\]|\\\\[\\s\\S])*\")");   // String literals
+
 std::vector<std::pair<int, int>>
 mark_redzones(const std::string& code)
 {
     // Find all the regions where comments and string exist
-    reflex::Pattern redzone_pattern(
-            "(?mx)"
-            "(\\/\\/[^\n]*\n)|"                 // Line comments
-            "(\\/\\*(?:\\*(?!\\/)|[^*])*\\*\\/)|" // Block comments
-            "(\"(?:[^\"\\\\]|\\\\[\\s\\S])*\")");   // String literals
     reflex::Matcher m(redzone_pattern, code);
     std::vector<std::pair<int, int>> out;
 

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -37,10 +37,11 @@ void CodeGenImpl::parse_header(const File* self)
 
     std::map<key_val_t, std::pair<const char*, up<Code>*>>
             single_appearance_map{
-            {KEY_VAL_TOP,    {"top",    &top}},
-            {KEY_VAL_BOTTOM, {"bottom", &bottom}},
-            {KEY_VAL_UNION,  {"union",  &union_}},
-            {KEY_VAL_LEXER,  {"lexer",  &lexer_input}},
+            {KEY_VAL_TOP,     {"top",     &top}},
+            {KEY_VAL_BOTTOM,  {"bottom",  &bottom}},
+            {KEY_VAL_UNION,   {"union",   &union_}},
+            {KEY_VAL_LEXER,   {"lexer",   &lexer_input}},
+            {KEY_VAL_INCLUDE, {"include", &include_}},
     };
 
     // Run round 1 of iterations
@@ -52,6 +53,7 @@ void CodeGenImpl::parse_header(const File* self)
             case KEY_VAL_TOP:
             case KEY_VAL_BOTTOM:
             case KEY_VAL_UNION:
+            case KEY_VAL_INCLUDE:
             case KEY_VAL_LEXER:
             {
                 auto &ptr = single_appearance_map[iter->type];

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -42,6 +42,7 @@ typedef enum
     KEY_VAL_UNION,
     KEY_VAL_DESTRUCTOR,
     KEY_VAL_LEXER,
+    KEY_VAL_INCLUDE,
 } key_val_t;
 
 typedef struct KeyVal_ KeyVal;

--- a/src/codegen/codegen_impl.h
+++ b/src/codegen/codegen_impl.h
@@ -19,6 +19,7 @@ struct CodeGenImpl
     up <Code> top;
     up <Code> bottom;
     up <Code> union_;
+    up <Code> include_;
 
     std::string start_type;
     std::string start_token;

--- a/src/codegen/compiler.c
+++ b/src/codegen/compiler.c
@@ -111,6 +111,13 @@ kv* declare_top(const TokenPosition* p, char* action)
     return key_val_build(p, KEY_VAL_TOP, NULL, action);
 }
 
+kv* declare_include(const TokenPosition* p, char* action)
+{
+    (void) declare_include;
+
+    return key_val_build(p, KEY_VAL_INCLUDE, NULL, action);
+}
+
 kv* declare_bottom(const TokenPosition* p, char* action)
 {
     (void) declare_bottom;

--- a/src/codegen/compiler.h
+++ b/src/codegen/compiler.h
@@ -19,6 +19,7 @@ kv* declare_right(struct Token* tokens);
 kv* declare_left(struct Token* tokens);
 kv* declare_bottom(const TokenPosition* p, char* action);
 kv* declare_top(const TokenPosition* p, char* action);
+kv* declare_include(const TokenPosition* p, char* action);
 kv* declare_union(const TokenPosition* p, char* action);
 
 lr_p* declare_lexer_rule(const TokenPosition* p, char* regex, char* action);

--- a/src/codegen/compiler_compiler.y
+++ b/src/codegen/compiler_compiler.y
@@ -91,6 +91,7 @@ static inline void ll_match_brace(ParsingStack* lex_state, const TokenPosition* 
 %token LEFT
 %token RIGHT
 %token TOP
+%token INCLUDE
 %token END_STATE
 %token<key_val> MACRO
 %token BOTTOM
@@ -167,6 +168,7 @@ static inline void ll_match_brace(ParsingStack* lex_state, const TokenPosition* 
 "%left"             { return LEFT; }
 "%right"            { return RIGHT; }
 "%top"              { return TOP; }
+"%include"          { return INCLUDE; }
 "%bottom"           { return BOTTOM; }
 "%destructor"       { return DESTRUCTOR; }
 "{macro}"           {
@@ -292,6 +294,7 @@ pair: OPTION IDENTIFIER '=' LITERAL         { $$ = declare_option($p1, $2, $4); 
     | RIGHT tokens                          { $$ = declare_right($2); }
     | LEFT tokens                           { $$ = declare_left($2); }
     | TOP ACTION                            { $$ = declare_top(&$2.position, $2.string); }
+    | INCLUDE ACTION                        { $$ = declare_include(&$2.position, $2.string); }
     | BOTTOM ACTION                         { $$ = declare_bottom(&$2.position, $2.string); }
     | UNION ACTION                          { $$ = declare_union(&$2.position, $2.string); }
     | MACRO                                 { $$ = $1; }

--- a/test/input/calculator.y
+++ b/test/input/calculator.y
@@ -1,8 +1,10 @@
-%top {
+%include {
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+}
 
+%top {
 // This is a calculator test program
 }
 

--- a/test/input/calculator_ascii.y
+++ b/test/input/calculator_ascii.y
@@ -1,8 +1,10 @@
-%top {
+%include {
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+}
 
+%top {
 // This is a calculator test program
 }
 

--- a/test/input/error_cb.y
+++ b/test/input/error_cb.y
@@ -1,7 +1,9 @@
-%top {
+%include {
 #include <stdlib.h>
 #include <stddef.h>
+}
 
+%top {
 void lexer_error_cb(const char* input,
                     const TokenPosition* position,
                     uint32_t offset);

--- a/test/input/simple_ast.y
+++ b/test/input/simple_ast.y
@@ -1,4 +1,4 @@
-%top {
+%include {
 #include <stdlib.h>
 
 typedef enum {
@@ -14,8 +14,10 @@ typedef enum {
     ATOM_DEFAULT_ON, //!< use(+)
     ATOM_DEFAULT_OFF, //!< use(-)
 } atom_use_default_t;
-
 typedef struct RequiredUse_prv RequiredUse;
+}
+
+%top {
 struct RequiredUse_prv {
     char* target;
     use_operator_t operator;


### PR DESCRIPTION
  - Brings struct/union definition into header
  - Add `%include` directive to share for header and source file
  - Large speedup for codegen by moving redzone regex to static global