### PR TITLE
Merge neoast-lexer code into neoast

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,12 @@
 add_library(neoast STATIC
         lr.c parser.c
-        ../include/neoast.h)
+        lexer/matcher.c
+        lexer/container.c
+        lexer/input.c
+)
 
-target_include_directories(neoast PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_include_directories(neoast
-        PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/../include
-        ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/reflex/include)
+target_include_directories(neoast PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 add_subdirectory(parsergen)
 add_subdirectory(codegen)
 add_subdirectory(util)
-add_subdirectory(lexer)

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -31,6 +31,7 @@ add_dependencies(neoast-exec neoast-bootstrap)
 target_include_directories(neoast-codegen PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../
         ${PROJECT_SOURCE_DIR}/third_party/reflex/src
+        ${PROJECT_SOURCE_DIR}/third_party/reflex/include
         ${INJA_INCLUDE_DIRECTORIES}
         )
 target_include_directories(neoast-exec PRIVATE
@@ -40,7 +41,6 @@ target_link_libraries(neoast-codegen
         neoast
         neoast-parsergen
         neoast-util
-        neoast-lexer
         reflex          # used to build regex DFAs
         reflex-unicode
         )

--- a/src/codegen/bootstrap/codegen_grammar.c
+++ b/src/codegen/bootstrap/codegen_grammar.c
@@ -15,7 +15,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "codegen/codegen.h"
 #include <string.h>

--- a/src/codegen/common.c
+++ b/src/codegen/common.c
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -1,7 +1,0 @@
-add_library(neoast-lexer STATIC
-        matcher.c
-        container.c
-        input.c
-        )
-
-target_include_directories(neoast-lexer PRIVATE ${PROJECT_SOURCE_DIR}/include)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 macro(CUnitTest name)
     add_mocked_test(${name}_C
             SOURCES ${name}_test.c
-            LINK_LIBRARIES neoast neoast-lexer
+            LINK_LIBRARIES neoast
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
             ENVIRONMENT ${EXEC_ENV}
             INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/src
@@ -56,7 +56,7 @@ add_mocked_test(integration_C
         ${simple_ast_parser_OUTPUT}
         ${error_parser_OUTPUT}
         # TODO Link tests against reflex generated lexer
-        LINK_LIBRARIES neoast m neoast-lexer
+        LINK_LIBRARIES neoast m
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/src
         ENVIRONMENT ${EXEC_ENV}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ add_mocked_test(macro_C
         LINK_LIBRARIES neoast neoast-codegen
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         ENVIRONMENT ${EXEC_ENV}
-        INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/src
+        INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/reflex/include
         )
 
 add_mocked_test(tablegen_C


### PR DESCRIPTION
The lexer needs to be linked into every program using the parser, we might as well merge the two libraries together.