### PR TITLE
Consolidate grammar reduction action for optimized instruction caching

### DIFF
--- a/.idea/dictionaries/tumbar.xml
+++ b/.idea/dictionaries/tumbar.xml
@@ -1,6 +1,7 @@
 <component name="ProjectDictionaryState">
   <dictionary name="tumbar">
     <words>
+      <w>dest</w>
       <w>firstof</w>
       <w>neoast</w>
       <w>tumbar</w>

--- a/include/neoast.h
+++ b/include/neoast.h
@@ -48,7 +48,7 @@ typedef struct LR_1_prv LR_1;
 typedef struct GrammarState_prv GrammarState;
 typedef struct CanonicalCollection_prv CanonicalCollection;
 
-typedef void (*parser_expr) (void* dest, void** values);
+typedef void (*parser_reduce) (uint32_t reduce_rule, void* dest, void** values);
 typedef void (*parser_destructor) (void* self);
 
 
@@ -108,7 +108,6 @@ struct GrammarRule_prv
     uint32_t token;
     uint32_t tok_n;
     const uint32_t* grammar;
-    parser_expr expr;
 };
 
 struct GrammarParser_prv
@@ -118,6 +117,7 @@ struct GrammarParser_prv
     const char* const* token_names;
     parser_destructor const* destructors;
     yy_error_cb parser_error;
+    parser_reduce parser_reduce;
 
     // Also number of columns
     uint32_t grammar_n;

--- a/src/codegen/bootstrap/codegen_grammar.c
+++ b/src/codegen/bootstrap/codegen_grammar.c
@@ -713,29 +713,57 @@ static void gg_build_file(CodegenUnion* dest, CodegenUnion* args)
     dest->file->grammar_rules = args[5].g_rule;
 }
 
+void parser_reduce_all(uint32_t rule_id, CodegenUnion* dest, CodegenUnion* args)
+{
+    // Don't actually do this in real life :)
+    // I'm lazy
+    static void (* const reduce_table[])(CodegenUnion*, CodegenUnion*) = {
+            NULL, NULL, // 0,1
+            gg_build_header, gg_build_union, // 2,3
+            gg_build_bottom, gg_build_destructor, // 4,5
+            NULL, gg_key_val_add_next, // 6,7
+            gg_build_l_rule_1, gg_build_l_rule_3, // 8,9
+            NULL, gg_build_l_rule_2, // 10,11
+            NULL, gg_build_tok, // 12,13
+            gg_build_single, NULL, // 14,15
+            gg_build_multi, gg_build_multi_empty, // 16,17
+            gg_build_grammar, NULL, // 18,19
+            gg_build_grammars, gg_build_file // 20,21
+    };
+
+    if (reduce_table[rule_id])
+    {
+        reduce_table[rule_id](dest, args);
+    }
+    else
+    {
+        *dest = args[0];
+    }
+}
+
 static const GrammarRule gg_rules[] = {
-        {.token=TOK_AUGMENT, .tok_n=1, .grammar=grammars[0]},
-        {.token=TOK_GG_KEY_VALS, .tok_n=1, .grammar=grammars[1]},
-        {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[2], .expr = (parser_expr) gg_build_header},
-        {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[3], .expr = (parser_expr) gg_build_union},
-        {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[4], .expr = (parser_expr) gg_build_bottom},
-        {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[5], .expr = (parser_expr) gg_build_destructor},
-        {.token=TOK_GG_HEADER, .tok_n=1, .grammar=grammars[6]},
-        {.token=TOK_GG_HEADER, .tok_n=2, .grammar=grammars[7], .expr = (parser_expr) gg_key_val_add_next},
-        {.token=TOK_GG_LEX_RULE, .tok_n=2, .grammar=grammars[8], .expr = (parser_expr) gg_build_l_rule_1},
-        {.token=TOK_GG_LEX_RULE, .tok_n=3, .grammar=grammars[9], .expr = (parser_expr) gg_build_l_rule_3},
-        {.token=TOK_GG_LEX_RULES, .tok_n=1, .grammar=grammars[10]},
-        {.token=TOK_GG_LEX_RULES, .tok_n=2, .grammar=grammars[11], .expr = (parser_expr) gg_build_l_rule_2},
-        {.token=TOK_GG_TOKENS, .tok_n=1, .grammar=grammars[12]},
-        {.token=TOK_GG_TOKENS, .tok_n=2, .grammar=grammars[13], .expr = (parser_expr) gg_build_tok},
-        {.token=TOK_GG_SINGLE_GRAMMAR, .tok_n=2, .grammar=grammars[14], .expr = (parser_expr) gg_build_single},
-        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=1, .grammar=grammars[15]},
-        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=3, .grammar=grammars[16], .expr = (parser_expr) gg_build_multi},
-        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=1, .grammar=grammars[17], .expr = (parser_expr) gg_build_multi_empty},
-        {.token=TOK_GG_GRAMMAR, .tok_n=3, .grammar=grammars[18], .expr = (parser_expr) gg_build_grammar},
-        {.token=TOK_GG_GRAMMARS, .tok_n=1, .grammar=grammars[19]},
-        {.token=TOK_GG_GRAMMARS, .tok_n=2, .grammar=grammars[20], .expr = (parser_expr) gg_build_grammars},
-        {.token=TOK_GG_FILE, .tok_n=7, .grammar=grammars[21], .expr = (parser_expr) gg_build_file},
+        {.token=TOK_AUGMENT, .tok_n=1, .grammar=grammars[0]}, // 0
+        {.token=TOK_GG_KEY_VALS, .tok_n=1, .grammar=grammars[1]}, // 1
+        {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[2]}, // 2
+        {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[3]}, // 3
+        {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[4]}, // 4
+        {.token=TOK_GG_KEY_VALS, .tok_n=2, .grammar=grammars[5]}, // 5
+        {.token=TOK_GG_HEADER, .tok_n=1, .grammar=grammars[6]}, // 6
+        {.token=TOK_GG_HEADER, .tok_n=2, .grammar=grammars[7]}, // 7
+        {.token=TOK_GG_LEX_RULE, .tok_n=2, .grammar=grammars[8]}, // 8
+        {.token=TOK_GG_LEX_RULE, .tok_n=3, .grammar=grammars[9]}, // 9
+        {.token=TOK_GG_LEX_RULES, .tok_n=1, .grammar=grammars[10]}, // 10
+        {.token=TOK_GG_LEX_RULES, .tok_n=2, .grammar=grammars[11]}, // 11
+        {.token=TOK_GG_TOKENS, .tok_n=1, .grammar=grammars[12]}, // 12
+        {.token=TOK_GG_TOKENS, .tok_n=2, .grammar=grammars[13]}, // 13
+        {.token=TOK_GG_SINGLE_GRAMMAR, .tok_n=2, .grammar=grammars[14]}, // 14
+        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=1, .grammar=grammars[15]}, // 15
+        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=3, .grammar=grammars[16]}, // 16
+        {.token=TOK_GG_MULTI_GRAMMAR, .tok_n=1, .grammar=grammars[17]}, // 17
+        {.token=TOK_GG_GRAMMAR, .tok_n=3, .grammar=grammars[18]}, // 18
+        {.token=TOK_GG_GRAMMARS, .tok_n=1, .grammar=grammars[19]}, // 19
+        {.token=TOK_GG_GRAMMARS, .tok_n=2, .grammar=grammars[20]}, // 20
+        {.token=TOK_GG_FILE, .tok_n=7, .grammar=grammars[21]}, // 21
 };
 
 uint8_t precedence_table[TOK_AUGMENT] = {0};
@@ -756,6 +784,7 @@ int gen_parser_init(GrammarParser* self, void** lexer_ptr)
     self->token_names = tok_names_errors;
     self->destructors = NULL;
     self->ascii_mappings = NULL;
+    self->parser_reduce = (parser_reduce) parser_reduce_all;
 
     *lexer_ptr = bootstrap_lexer_new(ll_rules,
                                      ll_rules_n,

--- a/src/codegen/codegen_template.cc
+++ b/src/codegen/codegen_template.cc
@@ -220,6 +220,7 @@ static GrammarParser parser = {
         .token_names = __neoast_token_names,
         .destructors = __neoast_token_destructors,
         .parser_error = {{ parser_error }},
+        .parser_reduce = (parser_reduce) __neoast_reduce_handler,
         .grammar_n = {{ grammar_n }},
         .token_n = TOK_AUGMENT - NEOAST_ASCII_MAX,
         .action_token_n = {{ action_n }}

--- a/test/input/calculator.y
+++ b/test/input/calculator.y
@@ -11,7 +11,7 @@
 // This is default, just want to test the parser
 %option parser_type="LALR(1)"
 %option debug_table="TRUE"
-%option annotate_line="FALSE"
+%option annotate_line="TRUE"
 %option debug_ids="$d+-/*^()ES"
 %option prefix="calc"
 

--- a/test/lr_test.c
+++ b/test/lr_test.c
@@ -91,6 +91,12 @@ uint32_t lalr_table[] = {
         LR_R(2), LR_R(2), LR_R(2), LR_E( ), LR_E( ), /* 6 */
 };
 
+static void reduce_generic(uint32_t id, CodegenStruct* dest, CodegenStruct* args)
+{
+    (void) id;
+    *dest = args[0];
+}
+
 void initialize_parser()
 {
     static LexerRule l_rules[] = {
@@ -133,6 +139,7 @@ void initialize_parser()
     p.token_n = TOK_AUGMENT;
     p.action_token_n = 3;
     p.token_names = token_error_names;
+    p.parser_reduce = (parser_reduce) reduce_generic;
 
     // Initialize the lexer regex rules
     lexer_parent = bootstrap_lexer_new((const LexerRule**) rules, &lex_n, 1, NULL,
@@ -148,7 +155,7 @@ CTEST(test_parser)
                               ";";  // b
     initialize_parser();
 
-    ParserBuffers* buf = parser_allocate_buffers(256, 256, sizeof(CodegenUnion), sizeof(CodegenUnion));
+    ParserBuffers* buf = parser_allocate_buffers(256, 256, sizeof(CodegenStruct), sizeof(CodegenUnion));
 
     void* lexer_inst = bootstrap_lexer_instance_new(lexer_parent, lexer_input, strlen(lexer_input));
     int32_t res_idx = parser_parse_lr(&p, lalr_table, buf, lexer_inst, bootstrap_lexer_next);

--- a/test/tablegen_test.c
+++ b/test/tablegen_test.c
@@ -156,6 +156,26 @@ void copy_op(CalculatorStruct* dest, CalculatorStruct* args)
 static GrammarParser p;
 static void* lexer_parent;
 
+static void (* const reduce_table[])(CalculatorStruct*, CalculatorStruct*) = {
+        NULL, copy_op,
+        NULL, group_op,
+        copy_op, binary_op,
+        binary_op, binary_op,
+        binary_op, binary_op
+};
+
+void reduce_handler(uint32_t reduce_id, CalculatorStruct* dest, CalculatorStruct* args)
+{
+    if (reduce_table[reduce_id])
+    {
+        reduce_table[reduce_id](dest, args);
+    }
+    else
+    {
+        *dest = args[0];
+    }
+}
+
 void initialize_parser()
 {
     static LexerRule l_rules_s0[] = {
@@ -193,16 +213,16 @@ void initialize_parser()
     static uint32_t a_r[] = {TOK_S};
 
     static GrammarRule g_rules[] = {
-            {.token = TOK_AUGMENT, .tok_n = 1, .grammar = a_r, .expr = NULL}, // Augmented rule
-            {.token = TOK_S, .tok_n = 1, .grammar = r8, .expr = (parser_expr) copy_op},
-            {.token = TOK_S, .tok_n = 0, .grammar = r9, .expr = NULL}, // Empty, no-op
-            {.token = TOK_E, .tok_n = 3, .grammar = r7, .expr = (parser_expr) group_op},
-            {.token = TOK_E, .tok_n = 1, .grammar = r1, .expr = (parser_expr) copy_op},
-            {.token = TOK_E, .tok_n = 3, .grammar = r6, .expr = (parser_expr) binary_op},
-            {.token = TOK_E, .tok_n = 3, .grammar = r5, .expr = (parser_expr) binary_op},
-            {.token = TOK_E, .tok_n = 3, .grammar = r4, .expr = (parser_expr) binary_op},
-            {.token = TOK_E, .tok_n = 3, .grammar = r3, .expr = (parser_expr) binary_op},
-            {.token = TOK_E, .tok_n = 3, .grammar = r2, .expr = (parser_expr) binary_op},
+            {.token = TOK_AUGMENT, .tok_n = 1, .grammar = a_r}, // Augmented rule
+            {.token = TOK_S, .tok_n = 1, .grammar = r8},
+            {.token = TOK_S, .tok_n = 0, .grammar = r9}, // Empty, no-op
+            {.token = TOK_E, .tok_n = 3, .grammar = r7},
+            {.token = TOK_E, .tok_n = 1, .grammar = r1},
+            {.token = TOK_E, .tok_n = 3, .grammar = r6},
+            {.token = TOK_E, .tok_n = 3, .grammar = r5},
+            {.token = TOK_E, .tok_n = 3, .grammar = r4},
+            {.token = TOK_E, .tok_n = 3, .grammar = r3},
+            {.token = TOK_E, .tok_n = 3, .grammar = r2},
     };
 
     static LexerRule* l_rules[] = {
@@ -216,6 +236,7 @@ void initialize_parser()
     p.action_token_n = 9;
     p.token_n = TOK_AUGMENT;
     p.token_names = token_error_names;
+    p.parser_reduce = (parser_reduce) reduce_handler;
 
     lexer_parent = bootstrap_lexer_new((const LexerRule**) l_rules, &lex_n, 1, NULL,
                                        offsetof(CalculatorStruct, position), NULL);


### PR DESCRIPTION
Makes better use of instruction cache by consolidating grammar reduction rules into a single function. Makes the size of each grammar rule smaller because it doesn't need to hold an extra function pointer per rule.

Tested with with AutoGentoo's cportage metadata parser and we see an increase in performance of about 13%! Destructors were left alone because they will not have a significant impact on performance.

Misc updates:
  - Cleans up lr(1) implementation
  - Fixed a bug in `lr_test.c` with value sizing
  - Cleaned up codegen for grammar rules