### PR TITLE
Fix short and empty input files

### DIFF
--- a/src/codegen/compiler_compiler.y
+++ b/src/codegen/compiler_compiler.y
@@ -230,9 +230,11 @@ static inline void ll_match_brace(const TokenPosition* start_position)
 }
 
 <S_MATCH_BRACE> {
-// TODO: Comments inside braces should not be ignored because we want
-//       codegen to paste these in
+// TODO: Comments inside braces should not be ignored because we want codegen to paste these in
 "/\*"               { yypush(S_COMMENT); }
+
+// Line comments
+"//[^\n]*"          { ll_add_to_brace(yytext, yylen); }
 
 // ASCII literals
 "{ascii}"           { ll_add_to_brace(yytext, yylen); }

--- a/src/codegen/main.c
+++ b/src/codegen/main.c
@@ -27,9 +27,13 @@
 #define ERROR_CONTEXT_LINE_N 3
 
 uint32_t cc_init();
+
 void cc_free();
+
 void* cc_allocate_buffers();
+
 void cc_free_buffers(void* self);
+
 struct File* cc_parse_len(void* buffers, const char* input, uint64_t input_len);
 
 static size_t line_n = 0;
@@ -49,7 +53,10 @@ static void put_position(const TokenPosition* self, const char* type)
         return;
     }
 
-    for (int i = (int)self->line - ERROR_CONTEXT_LINE_N; i < (int)self->line; i++)
+    // Get the number of digits in the line number:
+    int dig_n = snprintf(NULL, 0, "%+d", self->line);
+
+    for (int i = (int) self->line - ERROR_CONTEXT_LINE_N; i < (int) self->line; i++)
     {
         if (i < 0)
         {
@@ -60,19 +67,19 @@ static void put_position(const TokenPosition* self, const char* type)
         if (newline_pos)
         {
             fprintf(stderr,
-                    "% 3d | %.*s\n", i + 1,
-                    (int)(newline_pos - file_lines[i]),
+                    "% *d | %.*s\n", dig_n, i + 1,
+                    (int) (newline_pos - file_lines[i]),
                     file_lines[i]);
         }
         else
         {
-            fprintf(stderr, "% 3d | %s\n", i + 1, file_lines[i]);
+            fprintf(stderr, "% *d | %s\n", dig_n, i + 1, file_lines[i]);
         }
     }
 
     if (self->line > 0)
     {
-        for (int j = 0; j < self->col_start + 6; j++)
+        for (int j = 0; j < self->col_start + 3 + dig_n; j++)
         {
             fputc(' ', stderr);
         }
@@ -103,7 +110,7 @@ static char* read_file(FILE* fp, size_t* file_size)
     file_lines = malloc(sizeof(char*) * line_s);
 
     char* end = input;
-    while(*end)
+    while (*end)
     {
         if (line_n + 1 >= line_s)
         {
@@ -112,7 +119,7 @@ static char* read_file(FILE* fp, size_t* file_size)
         }
 
         file_lines[line_n++] = *end == '\n' ? ++end : end;
-        while(*end && *end != '\n') end++;
+        while (*end && *end != '\n') end++;
     }
 
     return input;

--- a/src/codegen/main.c
+++ b/src/codegen/main.c
@@ -43,13 +43,12 @@ static void put_position(const TokenPosition* self, const char* type)
     assert(type);
     assert(path);
 
-    if (!self)
+    if (!self || self->line >= line_n)
     {
         fprintf(stderr, "%s: ", type);
         return;
     }
 
-    assert(self->line < line_n);
     for (int i = (int)self->line - ERROR_CONTEXT_LINE_N; i < (int)self->line; i++)
     {
         if (i < 0)
@@ -100,7 +99,7 @@ static char* read_file(FILE* fp, size_t* file_size)
 
     /* Fill the file lines */
     line_n = 0;
-    size_t line_s = *file_size >> 6;
+    size_t line_s = *file_size >> 6 > 32 ? *file_size >> 6 : 32;
     file_lines = malloc(sizeof(char*) * line_s);
 
     char* end = input;


### PR DESCRIPTION
  - Short files were not able to be compiled be of assumptions we made while reading the input file about line size
  - Empty files were crashing because EOF does not have a valid line number.
  - Fixed block & line comments not getting detected in action blocks
  - Fixed escaped ASCII characters in both action blocks and global space
  - Fix error alignment with line numbers of different length:
```
  998 | pipeline:     pipeline '|' newline_list pipeline
  999 |                { $$ = command_connect ($1, $4, '|'); }
 1000 |      |     pipeline BAR_AND newline_list pipeline
                                    ^
Error at grammar/bash.y:1000: Undeclared token 'newline_list'
```