### PR TITLE
Improved conflict messages

### DIFF
--- a/src/codegen/codegen_impl.h
+++ b/src/codegen/codegen_impl.h
@@ -10,10 +10,12 @@
 #include "cg_grammar.h"
 #include "cg_lexer.h"
 #include "regex.h"
+#include "input_file.h"
 
 struct CodeGenImpl
 {
     CodeGen* parent;
+    InputFile* input;
 
     MacroEngine m_engine;
 
@@ -36,7 +38,6 @@ struct CodeGenImpl
     // Generated parser
     up<const char* []> token_names_ptr;
     up<GrammarParser> parser;
-    up<parsergen::DebugInfo> debug_info;
     up<parsergen::CanonicalCollection> cc;
     up<uint8_t[]> precedence_table;
     up<uint32_t[]> parsing_table;
@@ -46,9 +47,9 @@ struct CodeGenImpl
     uint32_t ascii_mappings[NEOAST_ASCII_MAX] = {0};
     std::map<int, int> precedence_mapping;
 
-    explicit CodeGenImpl(CodeGen* parent_);
+    explicit CodeGenImpl(CodeGen* parent_, InputFile* input_file);
     sp<CGToken> get_token(const std::string &name) const;
-    void parse(const File* self);
+    void parse();
 
     void write_header(std::ostream &os, bool dump_license=true) const;
     void write_source(std::ostream &os, bool dump_license=true) const;

--- a/src/codegen/codegen_priv.h
+++ b/src/codegen/codegen_priv.h
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 #include "cg_util.h"
-
+#include "input_file.h"
 
 #define CODEGEN_STRUCT "NeoastValue"
 #define CODEGEN_UNION "NeoastUnion"
@@ -34,7 +34,7 @@ class CodeGen
     CodeGenImpl* impl_;
 
 public:
-    explicit CodeGen(const File* self, const std::string& file_path);
+    explicit CodeGen(InputFile* input_file);
 
     sp<CGToken> get_token(const std::string &name) const;
     const char* get_start_token() const;

--- a/src/codegen/debug.cc
+++ b/src/codegen/debug.cc
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
     {
         try
         {
-            CodeGen cg(input.file, input.full_path);
+            CodeGen cg(&input);
             if (has_errors()) break;
 
             const parsergen::CanonicalCollection* cc = cg.get_impl()->cc.get();

--- a/src/codegen/input_file.h
+++ b/src/codegen/input_file.h
@@ -25,7 +25,9 @@
 #include <string>
 #include <sstream>
 
-struct InputFile
+#include <common/context.h>
+
+class InputFile : public Context
 {
     File* file;
     size_t file_length;
@@ -39,6 +41,10 @@ struct InputFile
     std::stringstream warning_stream;
     std::stringstream error_stream;
 
+    const char* get_line(uint32_t lineno, size_t &len) const;
+    void put_position(std::ostream& os, const TokenPosition* position) const;
+
+public:
     explicit InputFile(const std::string& file_path);
 
     ~InputFile()
@@ -47,13 +53,18 @@ struct InputFile
     }
 
     uint32_t put_errors() const;
+    uint32_t has_errors() const override { return err_n; }
 
-    const char* get_line(uint32_t lineno, size_t &len) const;
-    void put_position(std::ostream& os, const TokenPosition* position) const;
-    void emit_error(const TokenPosition* p, const char* format, ...);
+    inline const File* get() const { return file; }
+    inline const std::string& get_path() const { return full_path; }
+
     void emit_error(const TokenPosition* p, const char* format, va_list args);
-    void emit_warning(const TokenPosition* p, const char* format, ...);
     void emit_warning(const TokenPosition* p, const char* format, va_list args);
+
+    void emit_error_message(const TokenPosition* p, const char* format, ...) override;
+    void emit_error(const TokenPosition* p, const char* format, ...) override;
+    void emit_warning_message(const TokenPosition* p, const char* format, ...) override;
+    void emit_warning(const TokenPosition* p, const char* format, ...) override;
 };
 
 #endif //NEOAST_INPUT_FILE_H

--- a/src/codegen/main.cc
+++ b/src/codegen/main.cc
@@ -40,7 +40,7 @@ int main(int argc, const char* argv[])
 
     try
     {
-        CodeGen cg(input.file, input.full_path);
+        CodeGen cg(&input);
         std::ofstream h(output_h);
         std::ofstream c(output_c);
 

--- a/src/common/context.h
+++ b/src/common/context.h
@@ -15,30 +15,16 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef NEOAST_C_PUB_H
-#define NEOAST_C_PUB_H
+#ifndef NEOAST_CONTEXT_H
+#define NEOAST_CONTEXT_H
 
-#include <neoast.h>
+struct Context
+{
+    virtual uint32_t has_errors() const = 0;
+    virtual void emit_error_message(const TokenPosition* p, const char* format, ...) = 0;
+    virtual void emit_error(const TokenPosition* p, const char* format, ...) = 0;
+    virtual void emit_warning_message(const TokenPosition* p, const char* format, ...) = 0;
+    virtual void emit_warning(const TokenPosition* p, const char* format, ...) = 0;
+};
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-typedef enum {
-    LALR_1,  // Highly recommended!!
-    CLR_1,
-} parser_t;
-
-// C public API
-
-void* canonical_collection_init(const GrammarParser* parser, void* context, const void* der_positions);
-void canonical_collection_resolve(void* self, parser_t p_type);
-size_t canonical_collection_table_size(const void* self);
-uint32_t canonical_collection_generate(const void* self, uint32_t* table, const uint8_t* precedence_table);
-void canonical_collection_free(void* self);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif //NEOAST_C_PUB_H
+#endif //NEOAST_CONTEXT_H

--- a/src/parsergen/bit_vector.h
+++ b/src/parsergen/bit_vector.h
@@ -15,8 +15,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef NEOAST_CC_COMMON_H
-#define NEOAST_CC_COMMON_H
+#ifndef NEOAST_BIT_VECTOR_H
+#define NEOAST_BIT_VECTOR_H
 
 #include <vector>
 #include <cassert>
@@ -142,4 +142,4 @@ namespace parsergen
     };
 }
 
-#endif //NEOAST_CC_COMMON_H
+#endif //NEOAST_BIT_VECTOR_H

--- a/src/parsergen/c_pub.cc
+++ b/src/parsergen/c_pub.cc
@@ -18,9 +18,10 @@
 #include "c_pub.h"
 #include "canonical_collection.h"
 
-void* canonical_collection_init(const GrammarParser* parser, const void* debug_info)
+void* canonical_collection_init(const GrammarParser* parser, void* context, const void* der_positions)
 {
-    return new parsergen::CanonicalCollection(parser, static_cast<const parsergen::DebugInfo*>(debug_info));
+    return new parsergen::CanonicalCollection(parser, static_cast<Context*>(context),
+                                              static_cast<const TokenPosition* const*>(der_positions));
 }
 
 void canonical_collection_resolve(void* self, parser_t p_type)

--- a/src/parsergen/canonical_collection.cc
+++ b/src/parsergen/canonical_collection.cc
@@ -22,8 +22,9 @@
 
 namespace parsergen
 {
-    CanonicalCollection::CanonicalCollection(const GrammarParser* parser, const DebugInfo* debug_info)
-    : debug_info_(debug_info), parser_(parser), dfa_(nullptr), state_n_(0)
+    CanonicalCollection::CanonicalCollection(const GrammarParser* parser, Context* context,
+                                             const TokenPosition* const* reduce_positions)
+    : context_(context), parser_(parser), dfa_(nullptr), state_n_(0), reduce_positions_(reduce_positions)
     {
         // Initialize the grammar productions to an O(1) map
         for (uint32_t i = 0; i < parser_->grammar_n; i++)

--- a/src/parsergen/derivation.cc
+++ b/src/parsergen/derivation.cc
@@ -243,7 +243,11 @@ namespace parsergen
                 {
                     if (row[i] & TOK_REDUCE_MASK)
                     {
-                        // TODO
+                        cc->context()->emit_error(cc->get_position(lr1.derivation),
+                                                  "RR conflict, two rules are able to reduce on token '%s' (lookahead)",
+                                                  cc->parser()->token_names[i]);
+                        cc->context()->emit_error_message(cc->get_position(row[i] & TOK_MASK),
+                                                          "other rule attempting to reduce");
                         rr_conflicts++;
                     }
                     else if (row[i] & TOK_SHIFT_MASK)
@@ -260,9 +264,10 @@ namespace parsergen
                         }
                         else
                         {
-                            fprintf(stderr, "SR conflict tok %d state %d attempting to shift to %d\n",
-                                    i, get_id(),
-                                    row[i] & TOK_MASK);
+                            cc->context()->emit_error(cc->get_position(lr1.derivation),
+                                                      "SR conflict, trying to reduce with token %s but a rule "
+                                                      "is also attempting to shift this token",
+                                                      cc->parser()->token_names[i]);
                             sr_conflicts++;
                         }
                     }

--- a/src/parsergen/derivation.h
+++ b/src/parsergen/derivation.h
@@ -20,7 +20,7 @@
 
 #include <neoast.h>
 #include "c_pub.h"
-#include "cc_common.h"
+#include "bit_vector.h"
 
 #include <utility>
 #include <vector>

--- a/test/canonical_collection_test.cc
+++ b/test/canonical_collection_test.cc
@@ -121,7 +121,7 @@ CTEST(test_state_hash)
             {&simple::g_rules[0], 1, lookaheads},
     };
 
-    CanonicalCollection cc(&simple_p, nullptr);
+    CanonicalCollection cc(&simple_p, nullptr, nullptr);
 
     sp<GrammarState> s1(new GrammarState(&cc, items1, 0));
     sp<GrammarState> s2(new GrammarState(&cc, items2, 1));
@@ -168,7 +168,7 @@ CTEST(test_lr1_lr0_sorting)
 
 CTEST(test_tablegen)
 {
-    CanonicalCollection cc(&simple_p, nullptr);
+    CanonicalCollection cc(&simple_p, nullptr, nullptr);
     cc.resolve(LALR_1);
 
     std::unique_ptr<uint32_t[]> table = std::unique_ptr<uint32_t[]>(new uint32_t[cc.table_size()]);
@@ -183,7 +183,7 @@ CTEST(test_tablegen)
 
 CTEST(test_lookaheads)
 {
-    CanonicalCollection cc(&simple_p, nullptr);
+    CanonicalCollection cc(&simple_p, nullptr, nullptr);
 
     BitVector first_of_A(simple_p.action_token_n);
     first_of_A.select(1);

--- a/test/input/conflicts.y
+++ b/test/input/conflicts.y
@@ -1,0 +1,58 @@
+%include {
+#include <stdlib.h>
+#include <stddef.h>
+}
+
+%top {
+void lexer_error_cb(void* ctx,
+                    const char* input,
+                    const TokenPosition* position,
+                    const char* state_name);
+
+void parser_error_cb(void* ctx,
+                     const char* const* token_names,
+                     const TokenPosition* position,
+                     uint32_t last_token,
+                     uint32_t current_token,
+                     const uint32_t expected_tokens[],
+                     uint32_t expected_tokens_n);
+
+}
+
+%option prefix="error"
+%option parsing_error_cb="parser_error_cb"
+%option lexing_error_cb="lexer_error_cb"
+%option annotate_line="FALSE"
+
+%union {
+    int out;
+}
+
+// To generate conflicts, we will not put precedence on ambiguous operators
+//%left '+'
+//%left '-'
+//%right '*'
+//%right '/'
+
+%token<out> id
+%token ','
+%type optcomma
+%type<out> list
+%start<out> list
+
+==
+"[ \n\r]+"      { }
+==
+
+%%
+
+list    : id
+        | list optcomma id
+        | list ','               {yyerror ("extra comma ignored");}
+        ;
+optcomma: ','
+        |                        {yyerror ("missing comma inserted");}
+        ;
+
+
+%%

--- a/test/tablegen_test.c
+++ b/test/tablegen_test.c
@@ -258,7 +258,7 @@ void initialize_parser()
 CTEST(test_clr_1)
 {
     initialize_parser();
-    void* cc = canonical_collection_init(&p, NULL);
+    void* cc = canonical_collection_init(&p, NULL, NULL);
     canonical_collection_resolve(cc, CLR_1);
 
     uint32_t* table = malloc(sizeof(uint32_t) * canonical_collection_table_size(cc));
@@ -274,7 +274,7 @@ CTEST(test_clr_1)
 CTEST(test_lalr_1)
 {
     initialize_parser();
-    void* cc = canonical_collection_init(&p, NULL);
+    void* cc = canonical_collection_init(&p, NULL, NULL);
     canonical_collection_resolve(cc, LALR_1);
 
     uint32_t* table = malloc(sizeof(uint32_t) * canonical_collection_table_size(cc));
@@ -295,7 +295,7 @@ CTEST(test_lalr_1_calculator)
     ParserBuffers* buf = parser_allocate_buffers(256, 256, sizeof(CalculatorStruct),
                                                  offsetof(CalculatorStruct, position));
 
-    void* cc = canonical_collection_init(&p, NULL);
+    void* cc = canonical_collection_init(&p, NULL, NULL);
     canonical_collection_resolve(cc, LALR_1);
 
     uint32_t* table = malloc(sizeof(uint32_t) * canonical_collection_table_size(cc));
@@ -326,7 +326,7 @@ CTEST(test_lalr_1_order_of_ops)
     ParserBuffers* buf = parser_allocate_buffers(256, 256, sizeof(CalculatorStruct),
                                                  offsetof(CalculatorStruct, position));
 
-    void* cc = canonical_collection_init(&p, NULL);
+    void* cc = canonical_collection_init(&p, NULL, NULL);
     canonical_collection_resolve(cc, LALR_1);
 
     uint32_t* table = malloc(sizeof(uint32_t) * canonical_collection_table_size(cc));


### PR DESCRIPTION
What RR conflicts look like now:
```
/home/tumbar/git/neoast/test/input/conflicts.y:53:11: error: RR conflict, two rules are able to reduce on token 'id' (lookahead)
 53 | optcomma: ','
                ^~~
/home/tumbar/git/neoast/test/input/conflicts.y:51:34:  other rule attempting to reduce
 51 |         | list ','               {yyerror ("extra comma ignored");}
                                       ^
/home/tumbar/git/neoast/test/input/conflicts.y:  Failed to generate parsing table
Generated 0 warnings and 1 errors
```

Closes #75 