### PR TITLE
Support non printable tokens

### DIFF
--- a/src/codegen/cg_util.h
+++ b/src/codegen/cg_util.h
@@ -45,7 +45,6 @@ void put_enum(int start, const T& iterable, std::ostream& os,
     {
         if (_i < skip_start)
         {
-            ;
         }
         else if (is_first)
         {
@@ -57,7 +56,10 @@ void put_enum(int start, const T& iterable, std::ostream& os,
             os << variadic_string("    %s, // %d 0x%03X", i.c_str(), start, start);
             if (i.substr(0, 13) == "ASCII_CHAR_0x")
             {
-                os << variadic_string(" '%c'", std::stoul(i.substr(13), nullptr, 16));
+                char ascii = get_ascii_from_name(i.c_str());
+                const char* printable = get_ascii_printable(ascii);
+                if (printable) os << " '" << printable << "'";
+                else os << variadic_string(" '%c'", ascii);
             }
 
             os << "\n";

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -173,43 +173,10 @@ void CodeGenImpl::parse_header(const File* self)
     {
         if (tok->is_ascii)
         {
-            char ascii_char = get_ascii_from_name(tok->name.c_str());
-            switch(ascii_char)
-            {
-                case '\a':
-                    tokens_names.emplace_back("\\a");
-                    break;
-                case '\b':
-                    tokens_names.emplace_back("\\b");
-                    break;
-                case '\f':
-                    tokens_names.emplace_back("\\f");
-                    break;
-                case '\n':
-                    tokens_names.emplace_back("\\n");
-                    break;
-                case '\r':
-                    tokens_names.emplace_back("\\r");
-                    break;
-                case '\t':
-                    tokens_names.emplace_back("\\t");
-                    break;
-                case '\\':
-                    tokens_names.emplace_back("\\");
-                    break;
-                case '\'':
-                    tokens_names.emplace_back("'");
-                    break;
-                case '\"':
-                    tokens_names.emplace_back("\"");
-                    break;
-                case '\?':
-                    tokens_names.emplace_back("?");
-                    break;
-                default:
-                    tokens_names.emplace_back(std::string(1, ascii_char));
-                    break;
-            }
+            char ascii = get_ascii_from_name(tok->name.c_str());
+            const char* printable = get_ascii_printable(ascii);
+            if (printable) tokens_names.emplace_back(printable);
+            else tokens_names.emplace_back(1, ascii);
         }
         else
         {

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -120,6 +120,7 @@ struct Token* build_token(const TokenPosition* position, char* name);
 struct Token* build_token_ascii(const TokenPosition* position, char value);
 char* get_ascii_token_name(char value);
 char get_ascii_from_name(const char* name);
+const char* get_ascii_printable(char ascii);
 
 void tokens_free(struct Token* self);
 void key_val_free(KeyVal* self);

--- a/src/codegen/common.c
+++ b/src/codegen/common.c
@@ -53,6 +53,35 @@ char get_ascii_from_name(const char* name)
     return (char)strtoul(name + 13, NULL, 16);
 }
 
+const char* get_ascii_printable(char ascii)
+{
+    switch(ascii)
+    {
+        case '\a':
+            return "\\a";
+        case '\b':
+            return "\\b";
+        case '\f':
+            return "\\f";
+        case '\n':
+            return "\\n";
+        case '\r':
+            return "\\r";
+        case '\t':
+            return "\\t";
+        case '\\':
+            return "\\";
+        case '\'':
+            return "'";
+        case '\"':
+            return "\"";
+        case '\?':
+            return "?";
+        default:
+            return NULL;
+    }
+}
+
 struct Token* build_token_ascii(const TokenPosition* position, char value)
 {
     struct Token* self = malloc(sizeof(struct Token));


### PR DESCRIPTION
Fixes codegen for non printable characters:
```
    ASCII_CHAR_0x0A, // 303 0x12F '\n'
```